### PR TITLE
Add govuk_frontend_toolkit ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 gem 'devise', '~> 4.3'
 gem 'activeadmin', '~> 1'
+gem 'govuk_frontend_toolkit', '~> 6.0'
 
 group :development, :test do
   gem 'byebug', '~> 9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
     formtastic_i18n (0.6.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    govuk_frontend_toolkit (6.0.3)
+      rails (>= 3.1.0)
+      sass (>= 3.2.0)
     has_scope (0.7.1)
       actionpack (>= 4.1, < 5.2)
       activesupport (>= 4.1, < 5.2)
@@ -274,6 +277,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise (~> 4.3)
   dotenv (~> 2.2)
+  govuk_frontend_toolkit (~> 6.0)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
@@ -294,4 +298,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.0
+   1.15.1


### PR DESCRIPTION
Adds the govuk_frontend_toolkit gem to include the necessary scss and
templates.