### PR TITLE
Make CD possible for development

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,9 +2,7 @@ require_relative 'boot'
 
 require "rails"
 # Pick the frameworks you want:
-require "dotenv/load"
-require "active_model/railtie"
-require "active_job/railtie"
+require "dotenv/load" if Rails.env.development? || Rails.env.test?
 require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"


### PR DESCRIPTION
Stops dotenv trying to load in a production environment.