### PR TITLE
Add Basic Authentication until ready for users.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  if [Rails.env.production?, ENV["HTTP_USERNAME"], ENV["HTTP_PASSWORD"]].all?
+      http_basic_authenticate_with name: ENV["HTTP_USERNAME"], password: ENV["HTTP_PASSWORD"]
+  end
+
 end


### PR DESCRIPTION
Adds Basic Auth when in production and when HTTP_USERNAME and
HTTP_PASSWORD are set.  This can later be removed once we're happy
for people to start using it.