### PR TITLE
Add rake command to import organisations

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,40 @@
+require 'json'
+
+namespace :import do
+
+  desc "Import organisations from a data.gov.uk dump"
+  task :organisations, [:filename] => :environment do |_, args|
+    json_from_lines(args.filename) do |obj|
+
+      o = Organisation.find_by(name: obj["name"]) || Organisation.new
+
+      o.name = obj["name"]
+      o.title = obj["title"]
+      o.description = obj["description"]
+      o.abbreviation = obj["abbreviation"]
+      o.replace_by = "#{obj['replaced_by']}"
+      o.contact_email = obj["contact_email"]
+      o.contact_phone = obj["contact_phone"]
+      o.contact_name = obj["contact_name"]
+      o.foi_email = obj["foi_email"]
+      o.foi_phone = obj["foi_phone"]
+      o.foi_name = obj["foi_name"]
+      o.foi_web = obj["foi_web"]
+      o.category = obj["category"]
+      o.uuid = obj["id"]
+
+      o.save()
+    end
+  end
+
+end
+
+# Given a filename, will execute a block on each line
+# of the jsonl file, after the line has been decoded
+# into as hashmap.
+def json_from_lines(filename)
+  File.open(filename).each do |line|
+    yield JSON.parse(line)
+  end
+end
+


### PR DESCRIPTION
Given a jsonl encoded organisations list (from a live system dump) this
task will import (or update) organisations in the database.  Where the
name is in use, it will be overwritten by the values in the jsonl file.

```
rake import:organisations[path\to\dumpfile.jsonl]
```

The contents of the jsonl file are those retrieved from the daily dump of organisations and look like 

```json
{
    "abbreviation": "ACC",
    "approval_status": "pending",
    "category": "local-council",
    "contact-email": "",
    "contact-name": "",
    "contact-phone": "",
    "description": "Aberdeen City Council",
    "extras": [
        {
            "key": "abbreviation",
            "value": "ACC"
        },
        {
            "key": "category",
            "value": "local-council"
        },
        {
            "key": "contact-email",
            "value": ""
        },
        {
            "key": "contact-name",
            "value": ""
        },
        {
            "key": "contact-phone",
            "value": ""
        },
        {
            "key": "foi-email",
            "value": ""
        },
        {
            "key": "foi-name",
            "value": ""
        },
        {
            "key": "foi-phone",
            "value": ""
        },
        {
            "key": "foi-web",
            "value": "http://www.whatdotheyknow.com/body/aberdeen_city_council"
        }
    ],
    "foi-email": "",
    "foi-name": "",
    "foi-phone": "",
    "foi-web": "http://www.whatdotheyknow.com/body/aberdeen_city_council",
    "groups": [
        {
            "capacity": "public",
            "name": "local-authorities"
        }
    ],
    "id": "1cb62be8-50cd-4d87-869d-26dafeb5f649",
    "image_display_url": "",
    "image_url": "",
    "is_organization": true,
    "name": "aberdeen-city-council",
    "replaced_by": [],
    "state": "active",
    "tags": [],
    "title": "Aberdeen City Council",
    "type": "organization",
    "users": [
        {
            "capacity": "editor",
            "name": "SNIPPED"
        }
    ]
}
```

Some of these fields (tags, type) are irrelevant, and some need modifying.  For instance the category used here will need to be grouped into local,national,other as per find-data. But this can happen later.
