### PR TITLE
Use a real org in the task page

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,22 +1,21 @@
+require 'pp'
 class TasksController < ApplicationController
   protect_from_forgery prepend: :true
   before_action :authenticate_user!
 
   def my
     @organisation = current_user.primary_organisation
-    @datasets = Dataset.all
+    @datasets = Dataset.where(organisation: @organisation.id)
     @tasks = get_tasks_for_user(current_user)
-    @datasetsUpdate = @datasets.all
     @datasetsBroken = @datasets.all
   end
 
 
   def organisation
     @organisation = current_user.primary_organisation
-    @datasets = Dataset.all
+    @datasets = Dataset.where(organisation: @organisation.id)
     @tasks = get_tasks_for_organisation(@organisation.name)
-    @datasetsUpdate = @datasets.all
-    @datasetsBroken = @datasets.all
+    @datasetsBroken = @datasets
   end
 
 private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,4 @@
-require 'pp'
+
 class TasksController < ApplicationController
   protect_from_forgery prepend: :true
   before_action :authenticate_user!

--- a/app/views/tasks/_base.html.erb
+++ b/app/views/tasks/_base.html.erb
@@ -21,10 +21,10 @@
       </thead>
       <tbody>
 
-      <% @datasetsUpdate.each do |dataset| %>
+      <% @tasks.each do |task| %>
           <tr class="show-hide-item">
             <th>
-              <a href=""><%= dataset.title =%></a>
+              <a href=""><%= task.description =%></a>
             </th>
             <td>
               <span class="update-date">03 Feb 2017</span>
@@ -50,7 +50,7 @@
   <section class="show-hide">
     <div class="table-title">
       <h2 class="heading-medium">
-        <%=@tasks.count=%> datasets have broken data links
+        <%=@datasetsBroken.count=%> datasets have broken data links
       </h2>
     </div>
     <table>

--- a/app/views/tasks/my.html.erb
+++ b/app/views/tasks/my.html.erb
@@ -4,7 +4,7 @@
     <div class="tabs">
       <h2 class="heading-small">My tasks<div class="ie-fix"></div></h2>
       <div class="heading-small">
-        <%= link_to "#{@organisation.name} tasks", tasks_organisation_path %>
+        <%= link_to "#{@organisation.title} tasks", tasks_organisation_path %>
       </div>
     </div>
       <%= render partial: 'base' %>

--- a/app/views/tasks/organisation.html.erb
+++ b/app/views/tasks/organisation.html.erb
@@ -2,11 +2,11 @@
   <h1 class="heading-large">Tasks</h1>
   <div class="tasks">
     <div class="tabs">
-      <span class="visuallyhidden"> (<%=@organisation.name=%>)</span>
+      <span class="visuallyhidden"> (<%=@organisation.title =%>)</span>
       <div class="heading-small">
         <%= link_to "My tasks", tasks_path %>
       </div>
-      <h2 class="heading-small"><%=@organisation.name =%> tasks<div class="ie-fix"></div></h2>
+      <h2 class="heading-small"><%=@organisation.title =%> tasks<div class="ie-fix"></div></h2>
     </div>
     <%= render partial: 'base' %>
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,27 +5,34 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# We can create land-registry now, and if we import organisations
+# then they will just update it.
+land_registry = Organisation.new
+land_registry.name = "land-registry"
+land_registry.title = "Land Registry"
+land_registry.save!()
+
 admin = AdminUser.create!(
   email: 'admin@example.com',
   password: 'password',
-  password_confirmation: 'password')
+  password_confirmation: 'password'
+)
 
 publisher = User.create!(
   email: 'publisher@example.com',
   password: 'password',
   password_confirmation: 'password',
-  primary_organisation: Organisation.new(
-    name: 'Land Registry'
-  )
+  primary_organisation: land_registry
 )
 
 fix_task = Task.create!(
-  organisation: Organisation.new,
+  organisation: land_registry,
   description: 'fix this task'
 )
 
 update_task = Task.create!(
-  organisation: Organisation.new,
+  organisation: land_registry,
   description: 'update this task'
 )
 
@@ -33,19 +40,19 @@ price_paid_dataset = Dataset.create!(
   name: 'price paid data',
   title: 'Price Paid data for all London Boroughs',
   summary: 'Price Paid Data tracks the residential property sales in England and Wales that are lodged with HM Land Registry for registration. ',
-  organisation: Organisation.new
+  organisation: land_registry
 )
 
 hmrc_spending_dataset = Dataset.create!(
   name: 'HMRC spending',
   title: 'HMRC spending over £25000',
   summary: 'Monthly details of HMRC’s spending with suppliers covering transactions over £25,000',
-  organisation: Organisation.new
+  organisation: land_registry
 )
 
 council_tax_bands = Dataset.create!(
   name: 'Council Tax',
   title: 'Council Tax bands for London',
   summary: 'Council tax bands for the current year',
-  organisation: Organisation.new
+  organisation: land_registry
 )

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe "viewing tasks" do
+  before(:each) do
+    o = Organisation.new
+    o.name = 'land-registry'
+    o.title = 'Land Registry'
+    o.save!()
+
+    User.create!(email:'test@localhost',
+                 primary_organisation: o,
+                 password: 'password',
+                 password_confirmation: 'password')
+
+    fix_task = Task.create!(
+      organisation: o,
+      description: 'fix this task'
+    )
+
+    update_task = Task.create!(
+      organisation: o,
+      description: 'update this task'
+    )
+
+    price_paid_dataset = Dataset.create!(
+      name: 'price paid data',
+      title: 'Price Paid data for all London Boroughs',
+      summary: 'Price Paid Data tracks the residential property sales in England and Wales that are lodged with HM Land Registry for registration. ',
+      organisation: o
+    )
+  end
+
+  it "after login" do
+    visit '/'
+    click_link 'Sign in'
+    fill_in('user_email', with: 'test@localhost')
+    fill_in('Password', with: 'password')
+    click_button 'Sign in'
+    expect(page).to have_current_path '/tasks'
+
+    click_link 'Land Registry tasks'
+    expect(page).to have_selector(%(table), count: 2)
+    expect(page).to have_selector 'h2', :text => '2 datasets need to be updated'
+    expect(page).to have_selector 'h2', :text => '1 datasets have broken data links'
+
+  end
+end


### PR DESCRIPTION
Changes the seeds to use a real organisation (which may be updated after
organisation import) and then uses those details rather than all datasets.