### PR TITLE
Add search to manage page

### DIFF
--- a/app/controllers/manage_controller.rb
+++ b/app/controllers/manage_controller.rb
@@ -12,7 +12,6 @@ class ManageController < ApplicationController
     @datasets = get_query(false)
   end
 
-
   def get_query(with_owned)
     has_search_term = params[:q] != "" && params[:q] != nil
 
@@ -24,16 +23,17 @@ class ManageController < ApplicationController
       args[:creator_id] = current_user.id
     end
 
-    result = if has_search_term
-               args[:search] = params[:q].downcase
-               query_string = "name ILIKE CONCAT('%',:search,'%') OR title ILIKE CONCAT('%',:search,'%')"
-               Dataset.where(query_string, args)
-             else
-               Dataset.where(args)
-             end
+    perform_query(args, has_search_term).page params[:page]
+  end
 
-    result.page params[:page]
-
+  def perform_query(args, has_terms)
+    if has_terms
+      args[:search] = params[:q].downcase
+      query_string = "name ILIKE CONCAT('%',:search,'%') OR title ILIKE CONCAT('%',:search,'%')"
+      Dataset.where(query_string, args)
+    else
+      Dataset.where(args)
+    end
   end
 
   def set_common_args
@@ -43,5 +43,5 @@ class ManageController < ApplicationController
     @q = params[:q]
   end
 
-  private :set_common_args, :get_query
+  private :set_common_args, :get_query, :perform_query
 end

--- a/app/controllers/manage_controller.rb
+++ b/app/controllers/manage_controller.rb
@@ -25,12 +25,12 @@ class ManageController < ApplicationController
     end
 
     result = if has_search_term
-      args[:search] = params[:q].downcase
-      query_string = "name ILIKE CONCAT('%',:search,'%') OR title ILIKE CONCAT('%',:search,'%')"
-      Dataset.where(query_string, args)
-    else
-      Dataset.where(args)
-    end
+               args[:search] = params[:q].downcase
+               query_string = "name ILIKE CONCAT('%',:search,'%') OR title ILIKE CONCAT('%',:search,'%')"
+               Dataset.where(query_string, args)
+             else
+               Dataset.where(args)
+             end
 
     result.page params[:page]
 

--- a/app/controllers/manage_controller.rb
+++ b/app/controllers/manage_controller.rb
@@ -3,22 +3,45 @@ class ManageController < ApplicationController
   before_action :authenticate_user!
 
   def manage_own
-    @organisation = current_user.primary_organisation
-    @datasets = Dataset.where(
-                organisation: @organisation.id,
-                creator_id: current_user.id
-                ).page params[:page]
-    @find_url = ""
-    @sort = "published"
+    set_common_args
+    @datasets = get_query(true)
   end
 
   def manage_organisation
-    @organisation = current_user.primary_organisation
-    @datasets = Dataset.where(
-                organisation: @organisation.id
-                ).page params[:page]
-    @find_url = ""
-    @sort = "published"
+    set_common_args
+    @datasets = get_query(false)
   end
 
+
+  def get_query(with_owned)
+    has_search_term = params[:q] != "" && params[:q] != nil
+
+    args = {
+      organisation: @organisation.id,
+    }
+
+    if with_owned
+      args[:creator_id] = current_user.id
+    end
+
+    result = if has_search_term
+      args[:search] = params[:q].downcase
+      query_string = "name ILIKE CONCAT('%',:search,'%') OR title ILIKE CONCAT('%',:search,'%')"
+      Dataset.where(query_string, args)
+    else
+      Dataset.where(args)
+    end
+
+    result.page params[:page]
+
+  end
+
+  def set_common_args
+    @organisation = current_user.primary_organisation
+    @find_url = ""
+    @sort = "published"
+    @q = params[:q]
+  end
+
+  private :set_common_args, :get_query
 end

--- a/app/views/manage/manage_organisation.html.erb
+++ b/app/views/manage/manage_organisation.html.erb
@@ -7,7 +7,7 @@
     <div class="tabs">
       <span class="visuallyhidden"> (<%=@organisation.title =%>)</span>
       <div class="heading-small">
-        <%= link_to "My datasets", manage_path %>
+        <%= link_to "My datasets", manage_path(:q => @q) %>
       </div>
       <h2 class="heading-small"><%=@organisation.title =%> tasks<div class="ie-fix"></div></h2>
     </div>

--- a/app/views/manage/manage_own.html.erb
+++ b/app/views/manage/manage_own.html.erb
@@ -7,7 +7,7 @@
     <div class="tabs">
       <h2 class="heading-small">My datasets<div class="ie-fix"></div></h2>
       <div class="heading-small">
-        <%= link_to "#{@organisation.title} datasets", manage_organisation_path %>
+        <%= link_to "#{@organisation.title} datasets", manage_organisation_path(:q => @q) %>
       </div>
     </div>
       <%= render partial: 'base' %>

--- a/app/views/manage/shared/_search.html.erb
+++ b/app/views/manage/shared/_search.html.erb
@@ -4,7 +4,7 @@
     </a>
 </p>
 
-<form method="GET" action="/manage/" id="filter-dataset-form" class="form">
+<form method="GET" action="" id="filter-dataset-form" class="form">
   <fieldset>
     <legend class="visuallyhidden">
       Filter datasets by name
@@ -13,8 +13,9 @@
     <div class="form-group wide-search-bar">
       <label for="q">
         <div>Search all datasets</div>
-        <input class="form-control" id="q" name="q" type="text" autocomplete="off" value="">
+        <input class="form-control" id="q" name="q" type="text" autocomplete="off" value="<%= @q %>">
       </label>
+      <button class="button" id="search" name="search">Search</button>
     </div>
   </fieldset>
 </form>

--- a/spec/features/manage_spec.rb
+++ b/spec/features/manage_spec.rb
@@ -18,14 +18,22 @@ describe "managing datasets" do
       summary: 'Price Paid Data tracks the residential property sales in England and Wales that are lodged with HM Land Registry for registration. ',
       organisation: o
     )
-  end
 
-  it "after login" do
+    searchable = Dataset.create!(
+      name: 'searchable',
+      title: 'Find data here',
+      summary: 'A fake dataset for search ',
+      organisation: o
+    )
+
     visit '/'
     click_link 'Sign in'
     fill_in('user_email', with: 'test@localhost')
     fill_in('Password', with: 'password')
     click_button 'Sign in'
+  end
+
+  it "after login" do
     expect(page).to have_current_path '/tasks'
 
     # Don't expect any tables as creator_id not set on dataset
@@ -36,4 +44,23 @@ describe "managing datasets" do
     click_link 'Land Registry datasets'
     expect(page).to have_selector(%(table), count: 1)
   end
+
+  it "can do a search" do
+    click_link 'Manage datasets'
+    click_link 'Land Registry datasets'
+
+    # 4 TH includes 3 from header row
+    expect(page).to have_selector(%(th), count: 5)
+    fill_in('q', with: "find")
+    click_button 'Search'
+
+    # We expect to only have a single result now (plus the 3 header th)
+    expect(page).to have_selector(%(th), count: 4)
+
+    fill_in('q', with: "cats")
+    click_button 'Search'
+    # No results, no table.
+    expect(page).to have_selector(%(th), count: 0)
+  end
+
 end


### PR DESCRIPTION
Allows users to filter down their datasets, or their organisation datasets by searching.
This will perform a case insensitive search across their (or organisation) datasets.

Changing tab with a search term specified should ensure the search-term is carried
across and applied when loading that page.  So a search for 'cats' in my datasets will
also be applied when I click on my organisations datasets.