### PR TITLE
Overdue tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ $ rails s
 $ rake db:seed
 ```
 
+## Generating tasks
+
+### Checking for broken links
+
+```
+rake linkcheck:organisation[org-short-name]
+rake linkcheck:dataset[dataset-short-name]
+```
+
+### Checking for overdue dataset
+
+```
+rake overduecheck:organisation[org-short-name]
+rake overduecheck:dataset[dataset-short-name]
+```
+
 ## Extra ENV vars for production
 ```
 $ export PUBLISH_DATA_BETA_DATABASE_PASSWORD=...

--- a/lib/tasks/overdue.rake
+++ b/lib/tasks/overdue.rake
@@ -1,0 +1,16 @@
+require 'util/overduechecker'
+
+namespace :overduecheck do
+  desc "Check overdue datasets for the specified organisation"
+
+  task :organisation, [:organisation] => :environment do |_, args|
+    organisation = Organisation.find_by(name: args.organisation)
+    OverdueChecker.check_organisation(organisation)
+  end
+
+  task :dataset, [:dataset] => :environment do |_, args|
+    dataset = Dataset.find_by(name: args.dataset)
+    OverdueChecker.check_dataset(dataset)
+  end
+
+end

--- a/lib/util/overduechecker.rb
+++ b/lib/util/overduechecker.rb
@@ -1,0 +1,75 @@
+require 'pp'
+
+module OverdueChecker
+
+  @@frequencies = {
+    "monthly" => 30,
+    "annually" => 365,
+    "quarterly" => 90
+  }
+
+  # Checks for any overdue datasets in the organisation and creates a task if
+  # one does not already exist for each that is overdue.
+  def check_organisation(organisation)
+    puts "Checking datasets for #{organisation.title}"
+    Dataset.where(:organisation_id => organisation.id).find_each(:batch_size => 10) do |dataset|
+      check_dataset(dataset)
+    end
+
+  end
+
+  # Checks the dataset to see if it has a frequency, and whether the
+  # datafiles are up to date.
+  def check_dataset(dataset)
+    puts "Checking dataset #{dataset.title} (#{dataset.name})"
+
+    # If there is no frequency, then we bail quickly
+    return unless @@frequencies.key? dataset.frequency
+
+    # Skip if there is already a task for this dataset
+    return if Task.find_by(related_object_id: dataset.uuid)
+
+    # Finds the max end_date from the datafiles, then determines the
+    # number of days since that end_date.
+    max_end_date = find_end_date(dataset)
+    diff_days = (DateTime.now - max_end_date).to_i
+
+    # Check if the number of days since most recent datafile is >
+    # size of frequency (so > 30 for monthly, 365 for annual etc).
+    if diff_days > @@frequencies[dataset.frequency]
+      puts "Creating task for #{dataset.name}"
+      create_overdue_task(dataset, diff_days)
+    end
+  end
+
+  # Creates a new task for the overdue dataset, specifying when it
+  # should have been updated.
+  def create_overdue_task(dataset, days)
+
+    org = Organisation.find_by(id: dataset.organisation_id)
+
+    t = Task.new
+    t.organisation_id = org.id
+    t.owning_organisation = org.name
+    t.required_permission_name = ""
+    t.category = "overdue"
+    t.quantity = days
+    t.related_object_id = dataset.uuid
+    t.created_at = t.updated_at = DateTime.now
+    t.description = "'#{dataset.title}' is overdue"
+    t.save()
+
+  end
+
+  # Find the lastest end_date in the datafiles for this dataset and return
+  # it.
+  def find_end_date(dataset)
+    Datafile.where(:dataset_id => dataset.id).all.inject(Date.parse("2000-01-01")) {
+      |acc, datafile|
+        [datafile.end_date, acc].max
+    }
+  end
+
+  module_function :check_organisation, :check_dataset, :find_end_date, :create_overdue_task
+
+end

--- a/lib/util/overduechecker.rb
+++ b/lib/util/overduechecker.rb
@@ -1,4 +1,3 @@
-require 'pp'
 
 module OverdueChecker
 

--- a/lib/util/overduechecker.rb
+++ b/lib/util/overduechecker.rb
@@ -27,7 +27,8 @@ module OverdueChecker
     return unless @@frequencies.key? dataset.frequency
 
     # Skip if there is already a task for this dataset
-    return if Task.find_by(related_object_id: dataset.uuid)
+    return if Task.find_by(related_object_id: dataset.uuid,
+                           category: "overdue")
 
     # Finds the max end_date from the datafiles, then determines the
     # number of days since that end_date.


### PR DESCRIPTION
Provides a rask task which can check (at an organisation or at a dataset level
) for datasets with a frequency that are overdue.

If the frequency is not set, or a task for the dataset already exists, then
it will ignore that dataset.  Otherwise it will find the end-date for the latest
datafile and check if the dataset is missing a more recent entry.

Will require changes/refactor once model associations are done, and we still need
to find a way to do this for the entire catalogue on a schedule (maybe only weekly
for overdue datasets).

part of #50 