### PR TITLE
Improves styling on dataset forms

### DIFF
--- a/app/views/datasets/_dataset_field.html.erb
+++ b/app/views/datasets/_dataset_field.html.erb
@@ -1,4 +1,19 @@
 <div class="form-group<%= " error" if dataset.errors.keys.include?(field[:name])%>" id="<%= field[:name] %>-form-group">
+
+  <% if field[:input_type] == :radio_button %>
+    <span class="form-hint"><%= field.fetch(:hint, '') %></span>
+
+    <%= f.label field[:name].to_sym, class: field[:label_class] || 'form-label-bold' do %>
+      <%="#{field.fetch(:label, field[:name].humanize)}#{field[:optional] ? ' (optional)' : ''}" %>
+
+        <%= f.radio_button field[:name], (field[:value] || dataset.send(field[:name])),{
+           class: field[:input_class] || '',
+           id: field[:id] || "id_#{field[:name]}",
+           value: field[:value] || dataset.send(field[:name])
+         }.merge(field.fetch(:input_options, {})) %>
+    <% end %>
+
+  <% else %>
     <%= f.label field[:name].to_sym,
                 "#{field.fetch(:label, field[:name].humanize)}#{field[:optional] ? ' (optional)' : ''}",
                 class: field[:label_class] || 'form-label-bold'
@@ -6,25 +21,20 @@
 
     <span class="form-hint"><%= field.fetch(:hint, '') %></span>
 
-    <% if field[:input_type] == :radio_button %>
-      <%= f.radio_button field[:name], field[:value],
-                         {
-                           class: field[:input_class] || '',
-                           id: field[:id] || "id_#{field[:name]}",
-                           value: field[:value] || dataset.send(field[:name])
-                         }.merge(field.fetch(:input_options, {})) %>
-    <% elsif field[:input_type] %>
+    <% if field[:input_type] %>
       <%= f.send(field[:input_type],
                  field[:name],
                  {
-                   class: "form-control #{field[:input_class]}",
+                   class: "form-control #{field[:input_class]} form-control-2-3",
                    id: field[:id] || "id_#{field[:name]}",
                    value: field[:value] || dataset.send(field[:name])
                  }.merge(field.fetch(:input_options, {}))) %>
-    <% else %> 
+    <% else %>
       <%= f.text_field field[:name],
-                 class: "form-control #{field[:input_class]}",
+                 class: "form-control #{field[:input_class]} form-control-2-3",
                  id: field[:id] || "id_#{field[:name]}",
                  value: field[:value] || dataset.send(field[:name]) %>
     <% end %>
+  <% end %>
+
 </div>

--- a/app/views/datasets/adddoc.html.erb
+++ b/app/views/datasets/adddoc.html.erb
@@ -27,17 +27,20 @@
           <%= dataset_field f, @doc,
               name: 'url',
               label: 'URL',
+              input_class: 'form-control-2-3',
               hint: 'Enter a link (beginning with http:// or https://) to point directly to your document. The file will usually be uploaded to either your organisation’s website or another website, like GOV.UK or Amazon Web Services (AWS).',
               value: @doc.url %>
 
           <%= dataset_field f, @doc,
               name: 'name',
               label: 'Link name',
+              input_class: 'form-control-2-3',
               hint: 'The link name mustn’t be the same as the URL. It should clearly describe the document so users can find it easily.',
               value: @doc.name %>
-
-          <%= f.submit 'Save and continue', class: 'button' %>
-          <%= link_to 'Skip this step', publish_dataset_path(@dataset) %>
+          <div class="form-group">
+            <p><%= f.submit 'Save and continue', class: 'button' %></p>
+            <p><%= link_to 'Skip this step', publish_dataset_path(@dataset) %></p>
+          </div>
       <% end %>
-  </div>
+
 </main>

--- a/app/views/datasets/addfile.html.erb
+++ b/app/views/datasets/addfile.html.erb
@@ -27,17 +27,21 @@
           <%= dataset_field f, @datafile,
               name: 'url',
               label: 'URL',
+              input_class: 'form-control-2-3',
               hint: 'Enter a link (beginning with http:// or https://) to point directly to your data file. The file will usually be uploaded to either your organisation’s website or another website, like GOV.UK or Amazon Web Services (AWS).',
               value: @datafile.url %>
 
           <%= dataset_field f, @datafile,
               name: 'name',
               label: 'Link name',
+              input_class: 'form-control-2-3',
               hint: 'The link name mustn’t be the same as the URL. It should clearly describe the data so users can find it easily.',
               value: @datafile.name %>
 
-          <%= f.submit 'Save and continue', class: 'button' %>
-          <%= link_to 'Skip this step', new_adddoc_dataset_path(@dataset) %>
+          <div class="form-group">
+            <p><%= f.submit 'Save and continue', class: 'button' %></p>
+            <p><%= link_to 'Skip this step', new_adddoc_dataset_path(@dataset) %></p>
+          </div>
       <% end %>
   </div>
 </main>

--- a/app/views/datasets/licence.html.erb
+++ b/app/views/datasets/licence.html.erb
@@ -44,8 +44,10 @@
               label: 'Name of your licence:' %>
         </div>
 
-          <%= f.submit 'Save and continue', class: 'button' %>
-          <%= link_to 'Skip this step', new_location_dataset_path(@dataset) %>
+        <div class="form-group">
+          <p><%= f.submit 'Save and continue', class: 'button' %> </br></p>
+          <p><%= link_to 'Skip this step', new_location_dataset_path(@dataset) %></p>
+        </div>
       <% end %>
   </div>
 </main>

--- a/app/views/datasets/new.html.erb
+++ b/app/views/datasets/new.html.erb
@@ -26,16 +26,19 @@
       <%= form_for @dataset, action: 'create', method: 'post' do |f| %>
           <%= dataset_field f, @dataset,
               name: 'title',
+              input_class: 'form-control-2-3',
               hint: 'Titles should clearly describe the content of your dataset in under 65 characters' %>
 
           <%= dataset_field f, @dataset,
               name: 'summary',
+              input_class: 'form-control-2-3',
               input_type: :text_area,
               input_options: { rows: 4 },
               hint: 'Write a short description in plain English including any key information that will help users understand the dataset contents. Both the title and summary will appear in search results.' %>
 
           <%= dataset_field f, @dataset,
               name: 'description',
+              input_class: 'form-control-2-3',
               label: 'Additional information',
               optional: true,
               input_type: :text_area,


### PR DESCRIPTION
connected to #73 

- This PR adds missing class on text fields
- Nests the radio input within the radio label to fix styling.

Remaining issue: radio button styles only picked up if you land on the page after pressing skip on the previous page. If you've landed here from clicking submit (ie via Rails redirect_to) the styles aren't picked up. I think there is an issue with the js running on the page, maybe it's the order in which the assets are compiled? I don't know - I've not been able to fix it. 