### PR TITLE
Generates and uses slugs for datasets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'audited', '~> 4.5'
 gem 'kaminari', '~> 1.0.1'
 gem 'rest-client', '~> 2.0.2'
 gem 'mime-types', '~> 3.1'
+gem 'friendly_id', '~> 5.2.1'
 
 group :development, :test do
   gem 'byebug', '~> 9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
+    friendly_id (5.2.1)
+      activerecord (>= 4.0.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     govuk_frontend_toolkit (6.0.3)
@@ -334,6 +336,7 @@ DEPENDENCIES
   devise (~> 4.3)
   devise_invitable (~> 1.7.2)
   dotenv (~> 2.2)
+  friendly_id (~> 5.2.1)
   govuk_frontend_toolkit (~> 6.0)
   govuk_template (~> 0.22)
   guard

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -103,6 +103,6 @@ class DatasetsController < ApplicationController
   end
 
   def current_dataset
-    Dataset.find(params.require(:id))
+    Dataset.find_by(:name => params.require(:id))
   end
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -15,7 +15,7 @@ class Dataset < ApplicationRecord
 
   def title_and_sequence
     slug = title.to_param
-    sequence = Dataset.where("name like '#{slug}-%'").count + 2
+    sequence = Dataset.where("name like ?", "#{slug}-%").count + 2
     "#{slug}-#{sequence}"
   end
 

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -1,9 +1,23 @@
 class Dataset < ApplicationRecord
+  extend FriendlyId
+
   belongs_to :organisation
   has_many :datafiles
 
-  validates :title, presence: true, uniqueness: true
+  validates :title, presence: true
   validates :summary, presence: true
+
+  friendly_id :slug_candidates, :use => :slugged, :slug_column => :name
+
+  def slug_candidates
+    [:title, :title_and_sequence]
+  end
+
+  def title_and_sequence
+    slug = title.to_param
+    sequence = Dataset.where("name like '#{slug}-%'").count + 2
+    "#{slug}-#{sequence}"
+  end
 
   def published?
     published

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe Dataset do
+
+  let! (:org)  { @org = Organisation.create!(name: "land-registry", title: "Land Registry") }
+
+  it "can create a new dataset" do
+    d = Dataset.new
+    d.title = "This is a dataset"
+    d.summary = "Summary"
+    d.organisation_id = @org.id
+    expect(d.save).to eq(true)
+    expect(d.name).to eq("this-is-a-dataset")
+  end
+
+  it "can generate unique slugs" do
+    d1 = Dataset.new
+    d1.title = "dataset"
+    d1.summary = "Summary"
+    d1.organisation_id = @org.id
+    expect(d1.save).to eq(true)
+
+    d2 = Dataset.new
+    d2.title = "dataset"
+    d2.summary = "Summary"
+    d2.organisation_id = @org.id
+    expect(d2.save).to eq(true)
+
+    expect(d2.name).to eq("dataset-2")
+  end
+end


### PR DESCRIPTION
Datasets need to be available via a friendly url so we are using the
friendly_id gem to generate the unique slugs for each dataset into the
name field.  This included removing the rails unique constraint on the
title.

Requires a ```bundle install```, no migration.

Closes #80