### PR TITLE
Enforce stricter validation when publishing.

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -3,11 +3,22 @@ class Dataset < ApplicationRecord
 
   belongs_to :organisation
   has_many :datafiles
+  friendly_id :slug_candidates, :use => :slugged, :slug_column => :name
 
   validates :title, presence: true
   validates :summary, presence: true
 
-  friendly_id :slug_candidates, :use => :slugged, :slug_column => :name
+  validates :licence,
+    :presence => true,
+    :if => lambda{ published }
+
+  validates :frequency,
+    :presence => true,
+    :if => lambda{ published }
+
+  validate :dataset_must_have_datafiles_validation,
+    :if => lambda{ published }
+
 
   def slug_candidates
     [:title, :title_and_sequence]
@@ -30,4 +41,11 @@ class Dataset < ApplicationRecord
       "Draft"
     end
   end
+
+  def dataset_must_have_datafiles_validation
+    if self.datafiles.count() == 0
+      errors.add(:base, "Dataset must have at least one data file")
+    end
+  end
+
 end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -28,4 +28,29 @@ describe Dataset do
 
     expect(d2.name).to eq("dataset-2")
   end
+
+  it "validates more strictly when publishing" do
+    d = Dataset.new
+    d.title = "dataset"
+    d.summary = "Summary"
+    d.organisation_id = @org.id
+    d.published = true
+    expect(d.save).to eq(false)
+  end
+
+  it "can pass strict validation when publishing" do
+    d = Dataset.new
+    d.title = "dataset"
+    d.summary = "Summary"
+    d.organisation_id = @org.id
+    d.save()
+
+    Datafile.create(url: "http://127.0.0.1", name: "Test link", dataset: d)
+
+    d.frequency = "weekly"
+    d.licence = "uk-ogl"
+    d.published = true
+
+    expect(d.save).to eq(true)
+  end
 end


### PR DESCRIPTION
When publishing the licence, frequency and at least 1 data file are
required, so this PR will enforce that validation when published=true.

Closes #82