### PR TITLE
Update validation content

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -5,15 +5,20 @@ class Dataset < ApplicationRecord
   has_many :datafiles
   friendly_id :slug_candidates, :use => :slugged, :slug_column => :name
 
-  validates :title, presence: true
-  validates :summary, presence: true
+  validates :title,
+    presence: { message: "Please enter a valid title" },
+    length: { maximum: 100, message: "Ensure this value has at most 100 characters" }
 
-  validates :licence,
-    :presence => true,
-    :if => lambda{ published }
+  validates :summary,
+    presence: { message: "Please enter a valid summary" },
+    length: { maximum: 200, message: "Ensure this value has at most 200 characters" }
 
   validates :frequency,
-    :presence => true,
+    :presence => { message: "Please indicate how often this dataset is updated" },
+    :if => lambda { published }
+
+  validates :licence,
+    :presence => { message: "Please select a licence for your dataset" },
     :if => lambda{ published }
 
   validate :dataset_must_have_datafiles_validation,
@@ -44,7 +49,7 @@ class Dataset < ApplicationRecord
 
   def dataset_must_have_datafiles_validation
     if self.datafiles.count() == 0
-      errors.add(:base, "Dataset must have at least one data file")
+      errors.add(:base, "You must add at least one link")
     end
   end
 

--- a/app/views/datasets/_dataset_field.html.erb
+++ b/app/views/datasets/_dataset_field.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group<%= " error" if dataset.errors.keys.include?(field[:name])%>" id="<%= field[:name] %>-form-group">
+<div class="form-group<%= " error" if dataset.errors.include?(field[:name])%>" id="<%= field[:name] %>-form-group">
 
   <% if field[:input_type] == :radio_button %>
     <span class="form-hint"><%= field.fetch(:hint, '') %></span>
@@ -18,6 +18,10 @@
                 "#{field.fetch(:label, field[:name].humanize)}#{field[:optional] ? ' (optional)' : ''}",
                 class: field[:label_class] || 'form-label-bold'
     %>
+
+    <% if dataset.errors.key? field[:name] %>
+      <span class="error-message"><%= dataset.errors[field[:name]].first %></span>
+    <% end %>
 
     <span class="form-hint"><%= field.fetch(:hint, '') %></span>
 

--- a/app/views/datasets/new.html.erb
+++ b/app/views/datasets/new.html.erb
@@ -11,22 +11,23 @@
 				There was a problem
 			  </h1>
 			  <ul class="error-summary-list">
-                  <% @dataset.errors.each do |attr, message| %>
-                      <li>
-                          <a href="#<%= attr.to_s %>_form_group">
-                              <%= "#{attr.to_s.humanize} #{message}" %>
-                          </a>
-                          <span class="visuallyhidden">.</span>
-                      </li>
+          <% @dataset.errors.each do |attr, message| %>
+              <li>
+                  <a href="#<%= attr.to_s %>_form_group">
+                      <%= "Please enter a valid #{attr.to_s.humanize.downcase}" %>
+                  </a>
+                  <span class="visuallyhidden">.</span>
+              </li>
 				  <% end %>
 			  </ul>
 		  </div>
       <% end %>
 
       <%= form_for @dataset, action: 'create', method: 'post' do |f| %>
+
           <%= dataset_field f, @dataset,
               name: 'title',
-              input_class: 'form-control-2-3',
+              input_class: 'form-control-2-3 error',
               hint: 'Titles should clearly describe the content of your dataset in under 65 characters' %>
 
           <%= dataset_field f, @dataset,

--- a/spec/features/datasets_spec.rb
+++ b/spec/features/datasets_spec.rb
@@ -117,7 +117,7 @@ describe "creating and editing datasets" do
         fill_in "dataset[summary]", with: "my test dataset summary"
         click_button "Save and continue"
         expect(page).to have_content("There was a problem")
-        expect(page).to have_content("Title can't be blank")
+        expect(page).to have_content("Please enter a valid title")
         expect(Dataset.where(title: "my test dataset").length).to eq(0)
       end
 
@@ -125,15 +125,15 @@ describe "creating and editing datasets" do
         fill_in "dataset[title]", with: "my test dataset"
         click_button "Save and continue"
         expect(page).to have_content("There was a problem")
-        expect(page).to have_content("Summary can't be blank")
+        expect(page).to have_content("Please enter a valid summary")
         expect(Dataset.where(title: "my test dataset").length).to eq(0)
       end
 
       it "missing both" do
         click_button "Save and continue"
         expect(page).to have_content("There was a problem")
-        expect(page).to have_content("Title can't be blank")
-        expect(page).to have_content("Summary can't be blank")
+        expect(page).to have_content("Please enter a valid title")
+        expect(page).to have_content("Please enter a valid summary")
         expect(Dataset.where(title: "my test dataset").length).to eq(0)
       end
     end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -8,6 +8,7 @@ describe Dataset do
     d = Dataset.new
     d.title = "This is a dataset"
     d.summary = "Summary"
+    d.frequency = "daily"
     d.organisation_id = @org.id
     expect(d.save).to eq(true)
     expect(d.name).to eq("this-is-a-dataset")
@@ -18,12 +19,14 @@ describe Dataset do
     d1.title = "dataset"
     d1.summary = "Summary"
     d1.organisation_id = @org.id
+    d1.frequency = "daily"
     expect(d1.save).to eq(true)
 
     d2 = Dataset.new
     d2.title = "dataset"
     d2.summary = "Summary"
     d2.organisation_id = @org.id
+    d2.frequency = "daily"
     expect(d2.save).to eq(true)
 
     expect(d2.name).to eq("dataset-2")
@@ -34,6 +37,7 @@ describe Dataset do
     d.title = "dataset"
     d.summary = "Summary"
     d.organisation_id = @org.id
+    d.frequency = "daily"
     d.published = true
     expect(d.save).to eq(false)
   end
@@ -43,11 +47,11 @@ describe Dataset do
     d.title = "dataset"
     d.summary = "Summary"
     d.organisation_id = @org.id
+    d.frequency = "daily"
     d.save()
 
     Datafile.create(url: "http://127.0.0.1", name: "Test link", dataset: d)
 
-    d.frequency = "weekly"
     d.licence = "uk-ogl"
     d.published = true
 


### PR DESCRIPTION
Makes sure that content matches that in alpha, and also puts the
field error in the correct place for the form element.

Closes #32