### PR TITLE
Adds files list and documentation list during dataset creation

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -59,8 +59,26 @@ class DatasetsController < ApplicationController
       @datafile.dataset = @dataset
 
       if @datafile.save
-        redirect_to new_adddoc_dataset_path(@dataset)
+        redirect_to new_files_dataset_path(@dataset)
       end
+    end
+  end
+
+  def files
+    @dataset = current_dataset
+    @datafiles = @dataset.datafiles.datalinks
+
+    if request.post?
+      redirect_to new_adddoc_dataset_path(@dataset)
+    end
+  end
+
+  def documents
+    @dataset = current_dataset
+    @datafiles = @dataset.datafiles.documentation
+
+    if request.post?
+      redirect_to publish_dataset(@dataset)
     end
   end
 
@@ -74,7 +92,7 @@ class DatasetsController < ApplicationController
       @doc.documentation = true
       @doc.dataset = @dataset
 
-      redirect_to publish_dataset_path(@dataset) if @doc.save
+      redirect_to new_documents_dataset_path(@dataset) if @doc.save
     end
   end
 

--- a/app/views/datasets/_datafile_list.html.erb
+++ b/app/views/datasets/_datafile_list.html.erb
@@ -1,2 +1,0 @@
-
-Datafile list!!

--- a/app/views/datasets/_datafile_list.html.erb
+++ b/app/views/datasets/_datafile_list.html.erb
@@ -1,0 +1,2 @@
+
+Datafile list!!

--- a/app/views/datasets/documents.html.erb
+++ b/app/views/datasets/documents.html.erb
@@ -1,0 +1,40 @@
+
+<% content_for :page_title do %>
+    Links to supporting documents -
+<% end %>
+
+<main role="main" id="content">
+  <h1 class="heading-large">Links to supporting documents</h1>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Link name</th>
+        <th>Valid</th>
+        <th><span class="visuallyhidden">Actions</span></th>
+      </tr>
+    </thead>
+  <tbody>
+    <% @datafiles.each do |link| %>
+      <tr id="file_1">
+        <th><a href="<%= link.url %>"><%= link.name %></a></th>
+        <td>✔</td>
+        <td class="actions">
+          <a href="">Edit</a>
+          <a href="">Delete</a>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+  </table>
+
+  <p>
+    <%= link_to 'Add another link', new_adddoc_dataset_path(@dataset), class: "secondary-button" %>
+  </p>
+
+  <p>
+    <%= link_to 'Save and continue', publish_dataset_url(@dataset), class: "button" %>
+  </p>
+
+
+</main>

--- a/app/views/datasets/files.html.erb
+++ b/app/views/datasets/files.html.erb
@@ -1,0 +1,39 @@
+
+<% content_for :page_title do %>
+    Links to your data -
+<% end %>
+
+<main role="main" id="content">
+  <h1 class="heading-large">Links to your data</h1>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Link name</th>
+        <th>Valid</th>
+        <th><span class="visuallyhidden">Actions</span></th>
+      </tr>
+    </thead>
+  <tbody>
+    <% @datafiles.each do |link| %>
+      <tr id="file_1">
+        <th><a href="<%= link.url %>"><%= link.name %></a></th>
+        <td>✔</td>
+        <td class="actions">
+          <a href="">Edit</a>
+          <a href="">Delete</a>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+  </table>
+
+  <p>
+    <%= link_to 'Add another link', new_addfile_dataset_path(@dataset), class: "secondary-button" %>
+  </p>
+
+  <p>
+    <%= link_to 'Save and continue', new_adddoc_dataset_path(@dataset), class: "button" %>
+  </p>
+
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
       match 'new/location',  to: 'datasets#location',  via: [:get, :post]
       match 'new/frequency', to: 'datasets#frequency', via: [:get, :post]
       match 'new/addfile',   to: 'datasets#addfile',   via: [:get, :post]
+      match 'new/files',     to: 'datasets#files',   via: [:get, :post]
       match 'new/adddoc',    to: 'datasets#adddoc',    via: [:get, :post]
+      match 'new/documents', to: 'datasets#documents',   via: [:get, :post]
 
       match 'edit/licence',   to: 'datasets#edit_licence',   via: [:get, :put]
       match 'edit/location',  to: 'datasets#edit_location',  via: [:get, :put]

--- a/spec/features/datasets_spec.rb
+++ b/spec/features/datasets_spec.rb
@@ -81,6 +81,11 @@ describe "creating and editing datasets" do
       expect(Dataset.last.datafiles.last.url).to eq('https://localhost')
       expect(Dataset.last.datafiles.last.name).to eq('my test datafile')
 
+      # Files page
+      expect(page).to have_content("Links to your data")
+      expect(page).to have_content("my test datafile")
+      click_link "Save and continue"
+
       # Page 6: Add Documents
       fill_in 'datafile[url]', with: 'https://localhost/doc'
       fill_in 'datafile[name]', with: 'my test doc'
@@ -90,7 +95,12 @@ describe "creating and editing datasets" do
       expect(Dataset.last.datafiles.last.url).to eq('https://localhost/doc')
       expect(Dataset.last.datafiles.last.name).to eq('my test doc')
 
-      # Page 7: Publish Page
+      # Documents page
+      expect(page).to have_content("Links to supporting documents")
+      expect(page).to have_content("my test doc")
+      click_link "Save and continue"
+
+      # Page 9: Publish Page
       expect(Dataset.last.published).to be(false)
       expect(page).to have_content(Dataset.last.status)
       expect(page).to have_content(Dataset.last.organisation.title)


### PR DESCRIPTION
Shows a list of user's files after some have been added to allow for adding
more than one during dataset creation.  Does the same for documentation.

Currently the edit links don't work, although adding a new one does.

Closes #105