### PR TITLE
compile assets in staging

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 
 //= require rails-ujs
-//= require turbolinks
 //= require jquery
 //= require jquery_ujs
 //= require vendor/typeahead.bundle.min

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
- turbolinks not needed and cause errors with javascript in the body
- compile assets like in production - otherwise heroku tries to be clever but eventually fails to find some assets