### PR TITLE
Indexes the dataset on publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 2.4
 services:
   - postgresql
+  - elasticsearch
+before_script:
+  - sleep 10
 script:
   - bundle exec rake db:create
   - bundle exec rake db:migrate

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This repository contains the beta-stage data publishing component of data.gov.uk
 
 # Usage
 
+You will need postgres and elasticsearch installed for this to work.
+By default elastic is expected to be running on 127.0.0.1:9200 but if it isn't
+you can override the value by exporting ES_HOST=http://.... but make sure the URL
+does not end with a slash.
+
 ## First time setup
 ```
 $ export SECRET_KEY_BASE=...

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -90,7 +90,7 @@ class DatasetsController < ApplicationController
 
     if request.post?
       @dataset.published = true
-      @dataset. __elasticsearch__.index_document
+      @dataset.__elasticsearch__.index_document
 
       flash[:success] = I18n.t 'dataset_published'
       flash[:extra] = @dataset

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -90,6 +90,7 @@ class DatasetsController < ApplicationController
 
     if request.post?
       @dataset.published = true
+      @dataset. __elasticsearch__.index_document
 
       flash[:success] = I18n.t 'dataset_published'
       flash[:extra] = @dataset

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -41,7 +41,11 @@ class Dataset < ApplicationRecord
   # dataset.
   def as_indexed_json(_options={})
     as_json(
-      only: [:name, :title]
+      only: [:name, :title, :summary, :description,
+             :location1, :location2, :location3,
+             :licence, :licence_other, :frequency,
+             :published_date, :updated_at, :created_at,
+             :harvested, :uuid]
     )
   end
 

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -9,6 +9,8 @@ class Dataset < ApplicationRecord
 
   belongs_to :organisation
   has_many :datafiles
+  has_one :inspire_dataset
+
   friendly_id :slug_candidates, :use => :slugged, :slug_column => :name
 
   validates :frequency, inclusion: %w(daily weekly monthly quarterly annually financial-year never),
@@ -45,7 +47,12 @@ class Dataset < ApplicationRecord
              :location1, :location2, :location3,
              :licence, :licence_other, :frequency,
              :published_date, :updated_at, :created_at,
-             :harvested, :uuid]
+             :harvested, :uuid],
+      include: {
+        organisation: {},
+        datafiles: {},
+        inspire_dataset: {}
+      }
     )
   end
 

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -14,6 +14,10 @@ Elasticsearch::Model.client = Elasticsearch::Client.new(config)
 # Reset the search index before testing
 if Rails.env == "test"
   client = ::Dataset.__elasticsearch__.client
-  client.indices.delete index: ::Dataset.__elasticsearch__.index_name
+  begin
+    client.indices.delete index: ::Dataset.__elasticsearch__.index_name
+  rescue
+    puts "No test search index to delete"
+  end
   client.indices.create index: ::Dataset.__elasticsearch__.index_name
 end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -10,3 +10,9 @@ if File.exists?("config/elasticsearch.yml")
 end
 
 Elasticsearch::Model.client = Elasticsearch::Client.new(config)
+
+# Reset the search index before testing
+if Rails.env == "test"
+  client = ::Dataset.__elasticsearch__.client
+  client.indices.delete index: ::Dataset.__elasticsearch__.index_name
+end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -5,4 +5,8 @@ config = {
   }
 }
 
+if File.exists?("config/elasticsearch.yml")
+  config.merge!(YAML.load_file("config/elasticsearch.yml")[Rails.env].symbolize_keys)
+end
+
 Elasticsearch::Model.client = Elasticsearch::Client.new(config)

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -15,4 +15,6 @@ Elasticsearch::Model.client = Elasticsearch::Client.new(config)
 if Rails.env == "test"
   client = ::Dataset.__elasticsearch__.client
   client.indices.delete index: ::Dataset.__elasticsearch__.index_name
+  Dataset.__elasticsearch__.create_index! force: true
+  Dataset.__elasticsearch__.refresh_index!
 end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,5 +1,5 @@
 config = {
-  host: ENV["ES_HOST"] || "http://127.0.0.1:9200/",
+  host: ENV.fetch("ES_HOST", "http://127.0.0.1:9200"),
   transport_options: {
     request: { timeout: 5 }
   }

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -15,6 +15,5 @@ Elasticsearch::Model.client = Elasticsearch::Client.new(config)
 if Rails.env == "test"
   client = ::Dataset.__elasticsearch__.client
   client.indices.delete index: ::Dataset.__elasticsearch__.index_name
-  Dataset.__elasticsearch__.create_index! force: true
-  Dataset.__elasticsearch__.refresh_index!
+  client.indices.create index: ::Dataset.__elasticsearch__.index_name
 end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -5,7 +5,7 @@ config = {
   }
 }
 
-if File.exists?("config/elasticsearch.yml")
+if File.exist?("config/elasticsearch.yml")
   config.merge!(YAML.load_file("config/elasticsearch.yml")[Rails.env].symbolize_keys)
 end
 

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,0 +1,30 @@
+
+namespace :search do
+
+  desc "Reindex all datasets"
+  task :reindex => :environment do |_, args|
+
+    puts "Indexing #{Dataset.where(published: true).count()} datasets"
+
+    Dataset.where(published: true).find_in_batches do |datasets|
+      puts " Batching #{datasets.length} datasets"
+      bulk_index(datasets)
+    end
+
+  end
+
+  def bulk_index(datasets)
+    Dataset.__elasticsearch__.client.bulk({
+      index: ::Dataset.__elasticsearch__.index_name,
+      type: ::Dataset.__elasticsearch__.document_type,
+      body: prepare_records(datasets)
+    })
+  end
+
+  def prepare_records(datasets)
+    datasets.map do |dataset|
+      { index: { _id: dataset.id, data: dataset.as_indexed_json } }
+    end
+  end
+
+end

--- a/spec/features/datasets_spec.rb
+++ b/spec/features/datasets_spec.rb
@@ -326,6 +326,12 @@ describe "creating and editing datasets" do
 
       expect(page).to have_content("Your dataset has been published")
       expect(Dataset.last.published).to be(true)
+
+      # Ensure the dataset is indexed in Elastic
+      client = Dataset.__elasticsearch__.client
+      document = client.get({ index: Dataset.index_name, id: Dataset.last.id })
+      expect(document["_source"]["name"]).to eq("my-test-dataset")
+
     end
 
     describe "should set file dates correctly based on which frequency is set" do


### PR DESCRIPTION
When the user clicks publish (or republish) the dataset is now indexed in elastic. This includes the organisation, as well as datafiles (not separated) and any inspire metadata.

You can reindex all published datasets with ```rails search:reindex```

Config can be over-ridden by the presence of a elasticsearch.yml file in config/

Fixes #131 
Fixes #175

@govuklaurence @maxf @hannako You will need to have elasticsearch running on your machine after this PR.