### PR TITLE
Allow organisations to exist in a hierarchy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'cancancan', '~> 1.10'
 gem "elasticsearch", "~> 5.0.4"
 gem "elasticsearch-model", "~> 5.0.1"
 gem "elasticsearch-rails", "~> 5.0.1"
+gem "ancestry", "~> 3.0.1"
 
 group :development, :test do
   gem 'byebug', '~> 9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    ancestry (3.0.1)
+      activerecord (>= 3.2.0)
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (8.0.0)
@@ -357,6 +359,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin (~> 1)
+  ancestry (~> 3.0.1)
   audited (~> 4.5)
   byebug (~> 9)
   cancancan (~> 1.10)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,5 +1,6 @@
 class Organisation < ApplicationRecord
   extend FriendlyId
+  has_ancestry
 
   audited
   has_and_belongs_to_many :users

--- a/db/migrate/2017071231151258_add_ancestry_to_organisations.rb
+++ b/db/migrate/2017071231151258_add_ancestry_to_organisations.rb
@@ -1,0 +1,6 @@
+class AddAncestryToOrganisations < ActiveRecord::Migration[5.1]
+   def change
+      add_column :organisations, :ancestry, :string
+      add_index :organisations, :ancestry
+   end
+end


### PR DESCRIPTION
Uses the ancestry gem (https://github.com/stefankroes/ancestry) to add
support for organisations to use materialized path to mimic the
hierarchy.