### PR TITLE
Better handle the 'other' licences on import

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -71,9 +71,7 @@ namespace :import do
 
     json_from_lines(args.filename) do |obj|
       counter += 1
-      if counter % 500 == 0
-        puts "Completed #{counter}"
-      end
+      print "Completed #{counter}\r"
 
       MetadataTools.add_dataset_metadata(obj, orgs_cache)
     end


### PR DESCRIPTION
Also as a drive-by, renames get_doc_type to documentation? as suggested
by hannako elsewhere