### PR TITLE
Adds a temporary page to view metadata quality.

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -81,6 +81,17 @@ class DatasetsController < ApplicationController
 
   end
 
+  def quality
+    # A temporary page to show why some datasets are low quality
+    @dataset = current_dataset
+
+    require 'quality/quality_score'
+    q = QualityScore.new(current_dataset)
+
+    @score = q.score
+    @reasons = q.reasons
+  end
+
   private
   def current_dataset
     Dataset.find_by(:name => params.require(:id))

--- a/app/views/datasets/quality.html.erb
+++ b/app/views/datasets/quality.html.erb
@@ -1,0 +1,29 @@
+<% content_for :page_title do %>
+    Dataset quality -
+<% end %>
+
+<div class="grid-row">
+    <h1 class="heading-large">
+        Metadata quality for '<%= @dataset.title %>'
+    </h1>
+
+    <div class="data">
+        <span class="data-item bold-xlarge"><%= @score %>/100</span>
+    </div>
+
+    <% if @score != 100 %>
+      <h1 class="heading-medium">
+        Reasons
+      </h1>
+
+      <ul class="list list-bullet">
+        <% @reasons.each do |reason| %>
+          <li>
+            <%= reason %>
+          </li>
+        <% end %>
+      </ul>
+
+    <% end %>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,10 @@ Rails.application.routes.draw do
 
       post 'publish',       to: 'datasets#publish'
       get 'confirm_delete', to: 'datasets#confirm_delete'
+      get 'quality',        to: 'datasets#quality'
     end
   end
+
 
   get 'manage', to: 'manage#manage_own'
   get 'manage/organisation', to: 'manage#manage_organisation'

--- a/lib/quality/quality_score.rb
+++ b/lib/quality/quality_score.rb
@@ -42,11 +42,11 @@ class QualityScore
 
     # Are there any links at all?
     current = if links.size() == 0
-      @reasons << "There are no data links in this dataset"
-      10
-    else
-      0
-    end
+                @reasons << "There are no data links in this dataset"
+                10
+              else
+                0
+              end
 
     # Are any links broken?
     broken = links.select {|link| link.broken }

--- a/lib/quality/quality_score.rb
+++ b/lib/quality/quality_score.rb
@@ -29,7 +29,7 @@ class QualityScore
   end
 
   def documentation_score
-    if @dataset.docs.count() == 0
+    if @dataset.docs.count == 0
       @reasons << "There is no documentation for this data"
       5
     else
@@ -38,10 +38,10 @@ class QualityScore
   end
 
   def resource_score
-    links = @dataset.links.all()
+    links = @dataset.links.all
 
     # Are there any links at all?
-    current = if links.size() == 0
+    current = if links.size == 0
                 @reasons << "There are no data links in this dataset"
                 10
               else
@@ -50,7 +50,7 @@ class QualityScore
 
     # Are any links broken?
     broken = links.select {|link| link.broken }
-    if broken.size() > 0
+    if broken.size > 0
       @reasons << "There are broken links in this dataset"
       current += 10
     end
@@ -59,7 +59,7 @@ class QualityScore
   end
 
   def summary_score
-    if @dataset.summary.strip() == ""
+    if @dataset.summary.strip == ""
       @reasons << "This dataset has no summary"
       10
     else

--- a/lib/quality/quality_score.rb
+++ b/lib/quality/quality_score.rb
@@ -1,0 +1,103 @@
+class QualityScore
+  attr_reader :reasons
+
+  def initialize(dataset)
+    @dataset = dataset
+    @reasons = []
+  end
+
+  # Obtain a quality score for the dataset out of a maximum of 100.
+  # Points are removed for each failing feature of the dataset.
+  def score
+    value = 100
+
+    methods = QualityScore.instance_methods.grep(/.*_score/)
+    methods.each do | f |
+      value -= self.send(f)
+    end
+
+    value
+  end
+
+  def frequency_score
+    if @dataset.frequency.blank?
+      @reasons << "This dataset has no update frequency set"
+      10
+    else
+      0
+    end
+  end
+
+  def documentation_score
+    if @dataset.docs.count() == 0
+      @reasons << "There is no documentation for this data"
+      5
+    else
+      0
+    end
+  end
+
+  def resource_score
+    links = @dataset.links.all()
+
+    # Are there any links at all?
+    current = if links.size() == 0
+      @reasons << "There are no data links in this dataset"
+      10
+    else
+      0
+    end
+
+    # Are any links broken?
+    broken = links.select {|link| link.broken }
+    if broken.size() > 0
+      @reasons << "There are broken links in this dataset"
+      current += 10
+    end
+
+    current
+  end
+
+  def summary_score
+    if @dataset.summary.strip() == ""
+      @reasons << "This dataset has no summary"
+      10
+    else
+      0
+    end
+
+  end
+
+  def additional_notes_score
+    return 0 if @dataset.description.blank?
+    current = 0
+
+    if @dataset.description.length < 100
+      @reasons << "The additional information is very short"
+      current += 5
+    end
+
+    current
+  end
+
+  def contacts_score
+    org = @dataset.organisation
+    if org.contact_email.blank? && org.contact_phone.blank? && org.contact_name.blank?
+      @reasons << "The organisation has no contact details"
+      10
+    else
+      0
+    end
+  end
+
+  def licence_score
+    if @dataset.licence.blank?
+      @reasons << "This dataset has no licence"
+      10
+    else
+      0
+    end
+  end
+
+
+end

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -1,0 +1,13 @@
+require 'quality/quality_score'
+
+namespace :quality do
+
+  desc "Quality score for named dataset"
+  task :score,[:dataset] => :environment do |_, args|
+    dataset = Dataset.find_by(name: args.dataset)
+    q = QualityScore.new(dataset)
+    p q.score
+    p q.reasons
+  end
+
+end


### PR DESCRIPTION
Temporarily adds a new page to allow us to see why we think a dataset
is bad quality, it is at /datasets/NAME/quality.  We may (or not) want
to integrate something similar at some point so that publishers know
why we consider a dataset bad quality.

New scores can be added to the class at /lib/quality/quality_score
by adding a new method that ends with _score, it should return an integer.

This is to close https://trello.com/c/Dbs1tDIg/226-quality-reporting-in-publish