### PR TITLE
Remove attempt to load UUID extension

### DIFF
--- a/db/migrate/20170601084755_enable_uuid_extension.rb
+++ b/db/migrate/20170601084755_enable_uuid_extension.rb
@@ -1,5 +1,5 @@
 class EnableUuidExtension < ActiveRecord::Migration[5.1]
   def change
-    enable_extension 'uuid-ossp'
+    # enable_extension 'uuid-ossp'
   end
 end

--- a/db/migrate/20170601084755_enable_uuid_extension.rb
+++ b/db/migrate/20170601084755_enable_uuid_extension.rb
@@ -1,5 +1,4 @@
 class EnableUuidExtension < ActiveRecord::Migration[5.1]
   def change
-    # enable_extension 'uuid-ossp'
   end
 end

--- a/tools/paas.sh
+++ b/tools/paas.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This script should be run in front of each command is run in a PaaS ssh session:
+# eg.
+# $ cf ssh publish-data-alpha/app/src
+# > ../tools/paas.sh ./manage.py loaddata tasks
+
+export HOME=/home/vcap/app
+for f in ~/.profile.d/*; do
+    echo $f
+    source $f
+done
+$@


### PR DESCRIPTION
Otherwise migrations break on Paas.

Also adds the paas.sh to workaround PaaS not leaving bin/rails in a runnable state when you ssh in to the container.  Should run as 

```
cd app
../tools/paas.sh bin/rails something....
```
