### PR TITLE
Adds a model and a rake task for generating previews.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "ancestry", "~> 3.0.1"
 gem "govuk-lint", "~> 2.1.0"
 gem 'whois-parser'
 gem "sidekiq", "~> 5.0.4"
+gem 'iconv', "~> 1.0.4"
 
 group :development, :test do
   gem 'byebug', '~> 9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.8.4)
+    iconv (1.0.4)
     inherited_resources (1.7.2)
       actionpack (>= 3.2, < 5.2.x)
       has_scope (~> 0.6)
@@ -411,6 +412,7 @@ DEPENDENCIES
   govuk_template
   guard
   guard-rspec
+  iconv (~> 1.0.4)
   jbuilder (~> 2.5)
   kaminari (~> 1.0.1)
   launchy
@@ -437,4 +439,4 @@ DEPENDENCIES
   whois-parser
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -30,7 +30,6 @@ class Link < Datafile
   private
   def set_dates
     return if self.documentation
-    return if self.start_date.blank?
 
     set_weekly_dates           if dataset.weekly?
     set_monthly_dates          if dataset.monthly?

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -4,6 +4,8 @@ class Link < Datafile
   attr_accessor :start_day, :start_month, :start_year,
     :end_day, :end_month, :end_year
 
+  has_one :preview
+
   before_save :set_dates
 
   validates :quarter, presence: true,

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -1,0 +1,3 @@
+class Preview < ApplicationRecord
+  belongs_to :link
+end

--- a/db/migrate/20170731141237_add_previews.rb
+++ b/db/migrate/20170731141237_add_previews.rb
@@ -1,0 +1,9 @@
+class AddPreviews < ActiveRecord::Migration[5.1]
+  def change
+    create_table :previews do |t|
+      t.references :link, foreign_key: true
+      t.json :content
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170731141237_add_previews.rb
+++ b/db/migrate/20170731141237_add_previews.rb
@@ -1,7 +1,7 @@
 class AddPreviews < ActiveRecord::Migration[5.1]
   def change
     create_table :previews do |t|
-      t.references :link, foreign_key: true
+      t.references :datafiles, foreign_key: true
       t.json :content
       t.timestamps
     end

--- a/lib/preview/preview_generator.rb
+++ b/lib/preview/preview_generator.rb
@@ -39,7 +39,13 @@ class CSVPreviewGenerator
     file.unlink
 
     count = 0
+    CSVPreviewGenerator.get_rows(content, link.url)
+  end
+
+
+  def self.get_rows(content, from_url)
     rows = []
+    count = 0
 
     begin
       c = CSV.new(content, headers: true)
@@ -50,7 +56,7 @@ class CSVPreviewGenerator
       end
     rescue StandardError => e
       puts e.message
-      puts "\n#{link.url} is not a CSV so empty preview generated"
+      puts "\n#{from_url} is not a CSV so empty preview generated"
     end
 
     rows

--- a/lib/preview/preview_generator.rb
+++ b/lib/preview/preview_generator.rb
@@ -38,7 +38,6 @@ class CSVPreviewGenerator
     content = get_magic_encoding(file.path)
     file.unlink
 
-    count = 0
     CSVPreviewGenerator.get_rows(content, link.url)
   end
 

--- a/lib/tasks/preview.rake
+++ b/lib/tasks/preview.rake
@@ -1,0 +1,27 @@
+require 'json'
+require 'csv'
+require 'preview/preview_generator'
+
+namespace :preview do
+
+  desc "Generate a preview for all CSV links"
+  task :generate_all => :environment do |_, args|
+
+    counter = 0
+    total = Link.where(format: "CSV").count
+
+    print "There are #{total} links to process\n"
+
+    # Only generate previews for CSV right now, and only for ones
+    # that do not have previews already.
+    Link.where(format: "CSV").each do |link|
+      next if link.preview
+      print "Processing #{counter+=1}/#{total}\r"
+
+      PreviewGenerator.new(link).generate
+    end
+
+    puts
+  end
+
+end


### PR DESCRIPTION
This is the initial backend of the preview code.

Adds a new model linked to the link table, containing a json blob for
the preview of that link, if it's a CSV.

A new rake task ```preview:generate_all``` will iterate through the database
and find all links claiming to be CSVs (hint they're often not) and trying
to create a preview entry for them.

Because we don't have the faintest idea of what the encoding of the incoming CSV
is, we use the ```file``` command to find out what it is, and convert it to
UTF-8 if possible using iconv.

Still needs a UI, changes to dataset view to link to page and hooking in
to new links being created (as a sidekiq task). As preview blob is reasonably 
small, we might want to have it indexed with the link (or alternatively in a separate
index).

Requires a bundle install

Requires a migration