### PR TITLE
Create an organisations API endpoint

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,0 +1,15 @@
+class OrganisationsController < ApplicationController
+  protect_from_forgery prepend: :true
+
+  def lookup
+    if params[:q]
+      @query = params[:q].downcase
+      @organisations = Organisation.where("title ILIKE CONCAT('%',:search,'%')", {search: @query})
+    else
+      @organisations = Organisation.all
+    end
+
+    render json: @organisations.select('id, name, title, abbreviation')
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
   get 'manage/organisation', to: 'manage#manage_organisation'
 
   get 'api/locations', to: 'locations#lookup'
+  get 'api/organisations', to: 'organisations#lookup'
 
   get 'account/:id', to: 'account#show', as: 'account_show'
 end

--- a/spec/features/api/organisations_spec.rb
+++ b/spec/features/api/organisations_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe "Organisations API" do
+  before(:each) do
+    org = Organisation.new
+    org.name = 'land-registry'
+    org.title = 'Land Registry'
+    org.save!()
+  end
+
+  it 'sends a list of organisations' do
+    visit '/api/organisations?q=land'
+    json = JSON.parse(page.body)
+    expect(page.status_code).to be 200
+    expect(json.length).to eq(1)
+  end
+
+  it 'sends an empty list if no organisation matches' do
+    visit '/api/organisations?q=foobar'
+    json = JSON.parse(page.body)
+    expect(page.status_code).to be 200
+    expect(json.length).to eq(0)
+  end
+
+  it 'sends a full list if no query parameter sent' do
+    visit '/api/organisations'
+    json = JSON.parse(page.body)
+    expect(page.status_code).to be 200
+    expect(json.length).to eq(1)
+  end
+
+
+end


### PR DESCRIPTION
Can list all organisations at /api/organisations or query by passing a
query param called q like /api/organisations?q=cabin