### PR TITLE
A preview API

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,5 +1,6 @@
 class LinksController < ApplicationController
   before_action :set_current_dataset
+  skip_before_action :set_current_dataset, only: [:preview]
 
   def new
     @link = Link.new
@@ -58,6 +59,12 @@ class LinksController < ApplicationController
     @links = @dataset.links
   end
 
+  def preview
+    link = Link.find(params.require(:file_id))
+    render json: link.preview || {}
+  end
+
+
   private
   def set_current_dataset
     @dataset = current_dataset
@@ -70,4 +77,5 @@ class LinksController < ApplicationController
   def current_link
     Link.find(params.require(:file_id))
   end
+
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -4,7 +4,7 @@ class Link < Datafile
   attr_accessor :start_day, :start_month, :start_year,
     :end_day, :end_month, :end_year
 
-  has_one :preview
+  has_one :preview, foreign_key: "datafile_id"
 
   before_save :set_dates
 

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -1,3 +1,3 @@
 class Preview < ApplicationRecord
-  belongs_to :link
+  belongs_to :link, foreign_key: "datafile_id"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
 
   get 'api/locations', to: 'locations#lookup'
   get 'api/organisations', to: 'organisations#lookup'
+  get 'api/previews/:file_id', to: 'links#preview'
 
   get 'account/:id', to: 'account#show', as: 'account_show'
 end

--- a/db/migrate/20170731141237_add_previews.rb
+++ b/db/migrate/20170731141237_add_previews.rb
@@ -1,7 +1,7 @@
 class AddPreviews < ActiveRecord::Migration[5.1]
   def change
     create_table :previews do |t|
-      t.references :datafiles, foreign_key: true
+      t.references :link, foreign_key: true
       t.json :content
       t.timestamps
     end

--- a/db/migrate/20170731141237_add_previews.rb
+++ b/db/migrate/20170731141237_add_previews.rb
@@ -1,7 +1,7 @@
 class AddPreviews < ActiveRecord::Migration[5.1]
   def change
     create_table :previews do |t|
-      t.references :link, foreign_key: true
+      t.references :datafile, foreign_key: true
       t.json :content
       t.timestamps
     end

--- a/lib/preview/preview_generator.rb
+++ b/lib/preview/preview_generator.rb
@@ -16,7 +16,7 @@ class PreviewGenerator
       payload[:body] = CSVPreviewGenerator.create @link
     end
 
-    preview = Preview.new(link: @link, content: payload)
+    preview = Preview.new(datafile_id: @link.id, content: payload)
     preview.save!
   end
 

--- a/lib/preview/preview_generator.rb
+++ b/lib/preview/preview_generator.rb
@@ -11,6 +11,7 @@ class PreviewGenerator
   def generate
     payload = {}
     payload[:type] = @link.format
+    payload[:size] = @link.size
 
     if @link.format == "CSV"
       payload[:body] = CSVPreviewGenerator.create @link

--- a/lib/preview/preview_generator.rb
+++ b/lib/preview/preview_generator.rb
@@ -16,7 +16,7 @@ class PreviewGenerator
       payload[:body] = CSVPreviewGenerator.create @link
     end
 
-    preview = Preview.new(datafile_id: @link.id, content: payload)
+    preview = Preview.new(link: @link, content: payload)
     preview.save!
   end
 

--- a/spec/features/api/previews_spec.rb
+++ b/spec/features/api/previews_spec.rb
@@ -39,6 +39,7 @@ describe "Previews API" do
     json = JSON.parse(page.body)
     expect(page.status_code).to be 200
     expect(json["content"]["type"]).to eq("csv")
+    p json["content"]["size"]
   end
 
   it 'sends no preview if does not exist' do

--- a/spec/features/api/previews_spec.rb
+++ b/spec/features/api/previews_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe "Previews API" do
+  before(:each) do
+    org = Organisation.new
+    org.name = 'land-registry'
+    org.title = 'Land Registry'
+    org.save!()
+
+    ds = Dataset.new
+    ds.name = ds.title = ds.summary = 'preview-test'
+    ds.organisation = org
+    ds.frequency = "never"
+    ds.save!()
+
+    @link = Link.new
+    @link.name = "test"
+    @link.url = "http://127.0.0.1/fake"
+    @link.format = "csv"
+    @link.dataset = ds
+    @link.save!()
+
+    @noprev = Link.new
+    @noprev.name = "test"
+    @noprev.url = "http://127.0.0.1/fake2"
+    @noprev.format = "csv"
+    @noprev.dataset = ds
+    @noprev.save!()
+
+    @prev = Preview.new
+    @prev.link = @link
+    @prev.content = {type: "csv", body: '[["test"]]'}
+    @prev.save()
+
+  end
+
+  it 'sends a preview' do
+    visit "/api/previews/#{@link.id}"
+    json = JSON.parse(page.body)
+    expect(page.status_code).to be 200
+    expect(json["content"]["type"]).to eq("csv")
+  end
+
+  it 'sends no preview if does not exist' do
+    visit "/api/previews/#{@noprev.id}"
+    json = JSON.parse(page.body)
+    expect(page.status_code).to be 200
+    expect(json.size).to eq(0)
+  end
+
+  it 'sends nothing if file id not found' do
+    visit '/api/previews/10101010101010101'
+    expect(page.status_code).to be 404
+  end
+
+
+end

--- a/spec/features/api/previews_spec.rb
+++ b/spec/features/api/previews_spec.rb
@@ -31,7 +31,6 @@ describe "Previews API" do
     @prev.link = @link
     @prev.content = {type: "csv", body: '[["test"]]'}
     @prev.save!()
-
   end
 
   it 'sends a preview' do

--- a/spec/features/api/previews_spec.rb
+++ b/spec/features/api/previews_spec.rb
@@ -52,5 +52,4 @@ describe "Previews API" do
     expect(page.status_code).to be 404
   end
 
-
 end

--- a/spec/features/api/previews_spec.rb
+++ b/spec/features/api/previews_spec.rb
@@ -39,7 +39,6 @@ describe "Previews API" do
     json = JSON.parse(page.body)
     expect(page.status_code).to be 200
     expect(json["content"]["type"]).to eq("csv")
-    p json["content"]["size"]
   end
 
   it 'sends no preview if does not exist' do

--- a/spec/features/api/previews_spec.rb
+++ b/spec/features/api/previews_spec.rb
@@ -28,9 +28,9 @@ describe "Previews API" do
     @noprev.save!()
 
     @prev = Preview.new
-    @prev.link = @link
+    @prev.datafile_id = @link.id
     @prev.content = {type: "csv", body: '[["test"]]'}
-    @prev.save()
+    @prev.save!()
 
   end
 

--- a/spec/features/api/previews_spec.rb
+++ b/spec/features/api/previews_spec.rb
@@ -28,7 +28,7 @@ describe "Previews API" do
     @noprev.save!()
 
     @prev = Preview.new
-    @prev.datafile_id = @link.id
+    @prev.link = @link
     @prev.content = {type: "csv", body: '[["test"]]'}
     @prev.save!()
 


### PR DESCRIPTION
When a file id is given to /api/previews/:file_id then it will return a JSON
blob containing enough information to show a preview of the file.

e.g

```json
{
  id: 1,
  link_id: 11,
  content: {
    type: "CSV",
    body: [
	 [
	  "Name:",
	  "Age"
	],
	[
	  "Bob",
	  "23"
	],
	[
	  "Fred",
	  "24"
	],
	[
	  "Jane",
	  "22"
	]
      ]
    },
    created_at: "2017-08-02T14:23:03.710Z",
    updated_at: "2017-08-02T14:23:03.710Z"
}
```