### PR TITLE
Import Themes

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -17,6 +17,7 @@ class Dataset < ApplicationRecord
   before_save :set_uuid
 
   belongs_to :organisation
+  belongs_to :theme, optional: true
   has_many :links
   has_many :docs
   has_one :inspire_dataset

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -18,6 +18,8 @@ class Dataset < ApplicationRecord
 
   belongs_to :organisation
   belongs_to :theme, optional: true
+  belongs_to :secondary_theme, optional: true
+
   has_many :links
   has_many :docs
   has_one :inspire_dataset

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,0 +1,3 @@
+class Theme < ApplicationRecord
+  has_many :datasets
+end

--- a/db/migrate/20170804132533_add_theme_table.rb
+++ b/db/migrate/20170804132533_add_theme_table.rb
@@ -1,0 +1,9 @@
+class AddThemeTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :themes do |t|
+      t.string :name
+      t.string :title
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170804132655_add_theme_field_to_dataset.rb
+++ b/db/migrate/20170804132655_add_theme_field_to_dataset.rb
@@ -1,0 +1,6 @@
+class AddThemeFieldToDataset < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :theme_id, :integer
+  end
+end
+

--- a/db/migrate/20170804132655_add_theme_field_to_dataset.rb
+++ b/db/migrate/20170804132655_add_theme_field_to_dataset.rb
@@ -3,4 +3,3 @@ class AddThemeFieldToDataset < ActiveRecord::Migration[5.1]
     add_column :datasets, :theme_id, :integer
   end
 end
-

--- a/db/migrate/20170804132655_add_theme_field_to_dataset.rb
+++ b/db/migrate/20170804132655_add_theme_field_to_dataset.rb
@@ -1,5 +1,6 @@
 class AddThemeFieldToDataset < ActiveRecord::Migration[5.1]
   def change
     add_column :datasets, :theme_id, :integer
+    add_column :datasets, :secondary_theme_id, :integer
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,27 @@
 
 require 'csv'
 
+# Add default themes.  This is required before you can import the legacy metadata
+# so that we don't lose data in the migration
+
+Theme.create(
+  [
+    {name: "business-and-economy", title: "Business and economy"},
+    {name: "environment", title: "Environment"},
+    {name: "mapping", title: "Mapping"},
+    {name: "crime-and-justice", title: "Crime and justice"},
+    {name: "government", title: "Government"},
+    {name: "society", title: "Society"},
+    {name: "defence", title: "Defence"},
+    {name: "government-spending", title: "Government spending"},
+    {name: "towns-and-cities", title: "Towns and cities"},
+    {name: "education", title: "Education"},
+    {name: "health", title: "Health"},
+    {name: "transport", title: "Transport"},
+  ]
+)
+
+
 # We can create land-registry now, and if we import organisations
 # then they will just update it.
 land_registry = Organisation.new
@@ -46,58 +67,6 @@ User.create!(
   password_confirmation: 'password',
   primary_organisation: hmrc
 )
-
-# Fix task
-Task.create!(
-  organisation: land_registry,
-  description: 'fix this task'
-)
-
-# Update Task
-Task.create!(
-  organisation: land_registry,
-  description: 'update this task'
-)
-
-# Price paid dataset
-Dataset.create!(
-  name: 'price_paid_data',
-  title: 'Price Paid data for all London Boroughs',
-  summary: 'Price Paid Data tracks the residential property sales in England and Wales that are lodged with HM Land Registry for registration. ',
-  organisation: land_registry
-)
-
-# HMRC Spending dataset
-Dataset.create!(
-  name: 'hmrc_spending',
-  title: 'HMRC spending over £25000',
-  summary: 'Monthly details of HMRC’s spending with suppliers covering transactions over £25,000',
-  organisation: land_registry
-)
-
-# Council tax bands
-Dataset.create!(
-  name: 'council_tax',
-  title: 'Council Tax bands for London',
-  summary: 'Council tax bands for the current year',
-  organisation: land_registry
-)
-
-(1..5).each do |i|
-  Dataset.create!(
-    name: "lr_dataset_#{i}_name",
-    title: "LR_Dataset_#{i} title",
-    summary: "LR_Dataset_#{i} summary",
-    organisation: land_registry
-  )
-
-  Dataset.create!(
-  name: "hmrc_dataset_#{i}_name",
-  title: "HMRC_Dataset_#{i} title",
-  summary: "HMRC_Dataset_#{i} summary",
-  organisation: hmrc
-  )
-end
 
 # Locations
 location_csv_text = File.read('lib/seeds/locations.csv')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,23 +12,24 @@ require 'csv'
 # Add default themes.  This is required before you can import the legacy metadata
 # so that we don't lose data in the migration
 
-Theme.create(
-  [
-    {name: "business-and-economy", title: "Business and economy"},
-    {name: "environment", title: "Environment"},
-    {name: "mapping", title: "Mapping"},
-    {name: "crime-and-justice", title: "Crime and justice"},
-    {name: "government", title: "Government"},
-    {name: "society", title: "Society"},
-    {name: "defence", title: "Defence"},
-    {name: "government-spending", title: "Government spending"},
-    {name: "towns-and-cities", title: "Towns and cities"},
-    {name: "education", title: "Education"},
-    {name: "health", title: "Health"},
-    {name: "transport", title: "Transport"},
-  ]
-)
-
+if Theme.count == 0
+  Theme.create(
+    [
+      {name: "business-and-economy", title: "Business and economy"},
+      {name: "environment", title: "Environment"},
+      {name: "mapping", title: "Mapping"},
+      {name: "crime-and-justice", title: "Crime and justice"},
+      {name: "government", title: "Government"},
+      {name: "society", title: "Society"},
+      {name: "defence", title: "Defence"},
+      {name: "government-spending", title: "Government spending"},
+      {name: "towns-and-cities", title: "Towns and cities"},
+      {name: "education", title: "Education"},
+      {name: "health", title: "Health"},
+      {name: "transport", title: "Transport"},
+    ]
+  )
+end
 
 # We can create land-registry now, and if we import organisations
 # then they will just update it.

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -78,13 +78,14 @@ namespace :import do
 
     # Maps the organisation UUIDs to the organisation IDs
     orgs_cache =  Organisation.all.pluck(:uuid, :id).to_h
+    theme_cache = Theme.all.pluck(:title, :id).to_h
     counter = 0
 
     json_from_lines(args.filename) do |obj|
       counter += 1
       print "Completed #{counter}\r"
 
-      MetadataTools.add_dataset_metadata(obj, orgs_cache)
+      MetadataTools.add_dataset_metadata(obj, orgs_cache, theme_cache)
     end
   end
 

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -7,10 +7,11 @@ namespace :sync do
   task :daily => :environment do |_, args|
 
     orgs_cache =  Organisation.all.pluck(:uuid, :id).to_h
+    theme_cache = Theme.all.pluck(:title, :id).to_h
     count = 0
 
     get_packages "https://data.gov.uk" do |package|
-      MetadataTools.add_dataset_metadata(package, orgs_cache)
+      MetadataTools.add_dataset_metadata(package, orgs_cache, theme_cache)
       print "Imported #{count+=1} datasets...\r"
     end
 

--- a/lib/util/metadata_tools.rb
+++ b/lib/util/metadata_tools.rb
@@ -1,6 +1,6 @@
 module MetadataTools
 
-  def add_dataset_metadata(obj, orgs_cache)
+  def add_dataset_metadata(obj, orgs_cache, theme_cache)
     d = Dataset.find_or_create_by(uuid: obj["id"])
     d.name = obj["name"]
     d.title = obj["title"]
@@ -24,7 +24,8 @@ module MetadataTools
       d.licence = "other"
       d.licence_other = obj["license_id"]
     end
-
+    old_theme  = obj["theme-primary"]
+    d.theme_id = theme_cache.fetch(old_theme, nil)
     d.save!(validate: false)
 
     # Add the inspire metadata if we have determined this is a ULKP

--- a/lib/util/metadata_tools.rb
+++ b/lib/util/metadata_tools.rb
@@ -25,7 +25,9 @@ module MetadataTools
       d.licence_other = obj["license_id"]
     end
     old_theme  = obj["theme-primary"]
+    secondary_theme  = obj["theme-secondary"]
     d.theme_id = theme_cache.fetch(old_theme, nil)
+    d.secondary_theme_id = theme_cache.fetch(secondary_theme, nil)
     d.save!(validate: false)
 
     # Add the inspire metadata if we have determined this is a ULKP


### PR DESCRIPTION
When importing legacy datasets, this PR will attach a reference to an entry in the Theme
table so that we don't lose data.  We won't be displaying this anywhere right now though.

Some datasets don't have themes, in which case this will be nil.

The default themes are created in db:seed so this will need to be run for themes to be
created before import, otherwise there will be no theme references.