### PR TITLE
Revert "fix bug on import"

### DIFF
--- a/lib/util/metadata_tools.rb
+++ b/lib/util/metadata_tools.rb
@@ -115,7 +115,7 @@ module MetadataTools
 
   # Converts a legacy frequency into a new-style frequency
   def convert_frequency(dataset)
-    freq = dataset["frequency"]
+    freq = dataset["update_frequency"]
     return 'never' if !freq
 
     new_frequency = {
@@ -216,3 +216,4 @@ module MetadataTools
     :dataset_type, :get_extra, :harvested?, :calculate_dates_for_month, :calculate_dates_for_year,
     :documentation?, :get_start_end_date, :add_resource
 end
+


### PR DESCRIPTION
Reverts datagovuk/publish_data_beta#322

- This was right as it was. 
- The [`convert_frequency`](https://github.com/datagovuk/publish_data_beta/blob/393c4664a3c88672d0d4f8f7ac2d830dfba91502/lib/util/metadata_tools.rb#L10) function is taking the value stored in the legacy dataset key `update_frequency`, converting that value to match those we are handling in find beta, and then saving that value on `dataset.frequency`
- The [bug we currently have on production ](https://find-data-beta.herokuapp.com/dataset/cats-per-square-kilometre)is hopefully just because the [reindex failed](https://github.com/datagovuk/publish_data_beta/blob/393c4664a3c88672d0d4f8f7ac2d830dfba91502/lib/tasks/search.rake#L29). @maxf  is checking tomorrow :)
