### PR TITLE
Get location and last updated from legacy datasets

### DIFF
--- a/app/helpers/manage_helper.rb
+++ b/app/helpers/manage_helper.rb
@@ -1,7 +1,7 @@
 module ManageHelper
 
   SORT_OPTIONS = {"-name" => {title: :desc}}
-  SORT_OPTIONS.default = {updated_at: :desc}
+  SORT_OPTIONS.default = {last_updated_at: :desc}
 
   def manage_sort
     @name_sort = params["sort_by"] == "name" ? "-name" : "name"

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -50,7 +50,7 @@ class Dataset < ApplicationRecord
       only: [:name, :title, :summary, :description,
              :location1, :location2, :location3,
              :licence, :licence_other, :frequency,
-             :published_date, :updated_at, :created_at,
+             :published_date, :last_updated_at, :created_at,
              :harvested, :uuid],
       include: {
         organisation: {},

--- a/db/migrate/20170823141113_add_last_updated_at_to_dataset.rb
+++ b/db/migrate/20170823141113_add_last_updated_at_to_dataset.rb
@@ -1,0 +1,5 @@
+class AddLastUpdatedAtToDataset < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :last_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2017071231151258) do
-
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
     t.text "body"
@@ -111,6 +110,7 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.string "stage"
     t.integer "theme_id"
     t.integer "secondary_theme_id"
+    t.datetime "last_updated_at"
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end
 

--- a/lib/util/metadata_tools.rb
+++ b/lib/util/metadata_tools.rb
@@ -147,7 +147,7 @@ module MetadataTools
       ""
     end
   end
-  
+
   # Determine the type of dataset based on the presence of
   # a known INSPIRE key.
   def dataset_type(obj)
@@ -223,5 +223,5 @@ module MetadataTools
 
   module_function :add_dataset_metadata, :generate_summary, :convert_frequency, :add_inspire_metadata,
     :dataset_type, :get_extra, :harvested?, :calculate_dates_for_month, :calculate_dates_for_year,
-    :documentation?, :get_start_end_date, :add_resource
+    :documentation?, :get_start_end_date, :add_resource, :convert_location
 end

--- a/lib/util/metadata_tools.rb
+++ b/lib/util/metadata_tools.rb
@@ -11,10 +11,10 @@ module MetadataTools
     d.published = false
     d.published_date = obj["metadata_created"]
     d.created_at = obj["metadata_created"]
-    d.updated_at = obj["metadata_modified"]
+    d.last_updated_at = obj["metadata_modified"]
     d.dataset_type = dataset_type(obj)
     d.harvested = harvested?(obj)
-    d.location1 = ""
+    d.location1 = convert_location(obj)
     d.location2 = ""
     d.location3 = ""
     d.legacy_metadata = ""
@@ -139,6 +139,15 @@ module MetadataTools
     new_frequency
   end
 
+  def convert_location(obj)
+    loc = obj.fetch("geographic_coverage", [])
+    if loc.is_a? Array
+      loc.map(&:titleize).join(', ')
+    else
+      ""
+    end
+  end
+  
   # Determine the type of dataset based on the presence of
   # a known INSPIRE key.
   def dataset_type(obj)

--- a/lib/util/metadata_tools.rb
+++ b/lib/util/metadata_tools.rb
@@ -61,7 +61,7 @@ module MetadataTools
     datafile.name = resource["description"]
     datafile.name = "No name specified" if datafile.name.strip() == ""
     datafile.created_at = dataset.created_at
-    datafile.updated_at = dataset.updated_at
+    datafile.updated_at = dataset.last_updated_at
 
     if !resource["date"].blank? && !documentation?(resource['format'])
       dates = get_start_end_date(resource["date"])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,5 +59,5 @@ RSpec.configure do |config|
 end
 
 def last_updated_dataset
-  Dataset.order(:last_updated_at).last
+  Dataset.order(:updated_at).last
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,5 +59,5 @@ RSpec.configure do |config|
 end
 
 def last_updated_dataset
-  Dataset.order(:updated_at).last
+  Dataset.order(:last_updated_at).last
 end

--- a/spec/support/dataset_helper.rb
+++ b/spec/support/dataset_helper.rb
@@ -35,6 +35,7 @@ def set_up_models
                                                   frequency: 'never',
                                                   licence: 'uk-ogl',
                                                   published: true,
+                                                  last_updated_at: Time.now,
                                                   links: [FactoryGirl.create(:link, name: "my published test file")],
                                                   docs: [FactoryGirl.create(:doc, name: "my published test doc")],
                                                   creator: user,
@@ -48,6 +49,7 @@ def set_up_models
                                                     licence: 'uk-ogl',
                                                     location1: 'somewhere',
                                                     published: false,
+                                                    last_updated_at: Time.now,
                                                     links: [FactoryGirl.create(:link, name: "my published test file")],
                                                     docs: [FactoryGirl.create(:doc, name: "my published test doc")],
                                                     creator: user,
@@ -58,6 +60,7 @@ def set_up_models
                                                    organisation: land,
                                                    creator: user,
                                                    owner: user,
+                                                   last_updated_at: Time.now,
                                                    title: 'test title unfinished',
                                                    summary: 'test summary') }
 


### PR DESCRIPTION
- This is the back end part of the fix for this [pr](https://github.com/datagovuk/find_data_beta/pull/180). 

- We are storing the value in `metadata_modified` on the legacy dataset in `dataset.last_updated_at`

- This PR also gets the `geographic_coverage` value from legacy datasets and stores in in `location1`