### PR TITLE
Allow more workers on sidekiq

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
-worker: bundle exec sidekiq -c 1
+worker: bundle exec sidekiq -c 10

--- a/docs/first-time-setup.md
+++ b/docs/first-time-setup.md
@@ -1,0 +1,54 @@
+# First time setup
+
+## Publish Setup
+First, follow the steps on the first page for setting up Publish Data.
+
+## Importing data dumps
+```
+$ wget https://data.gov.uk/data/dumps/data.gov.uk-ckan-meta-data-latest.organizations.jsonl.gz
+$ wget https://data.gov.uk/data/dumps/data.gov.uk-ckan-meta-data-latest.v2.jsonl.gz
+```
+
+Rename them to make this easier...
+```
+$ mv data.gov.uk-ckan-meta-data-latest.v2.jsonl.gz datasets.jsonl.gz
+$ mv data.gov.uk-ckan-meta-data-latest.organizations.jsonl.gz orgs.jsonl.gz
+```
+
+Unzip
+```
+$ gunzip *.gz
+```
+
+At this point, ensure:
+* Your database is set up
+* Redis is running
+* Sidekiq is running
+* Elasticsearch is running
+* You can start the app
+
+Load Data
+```
+$ rails import:organisations[orgs.jsonl]
+$ rails import:datasets[datasets.jsonl]
+```
+
+That second command is going to take a while...
+
+You can watch indexing happenning real-time on your elasticsearch process, and if you start the app and go to the `/sidekiq` route you'll see the preview generation jobs in the queue.
+
+## If you need to reindex or regenerate previews...
+### Indexes
+
+Make sure you're pointed at your local index
+```
+$ rails search:reindex
+```
+
+### Previews
+```
+$ rails generate:purge_previews
+$ rails generate:previews
+```
+
+This one adds a lot of sidekiq jobs, so make sure it's running or they won't regen.


### PR DESCRIPTION
It was reduced to 1 initially because sidekiq was eating all the redis connections. We have 20 and I'm not letting sidekiq have 10 connections.

This should in theory increase the job processing rate tenfold.