### PR TITLE
Avoid file slurping

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -96,7 +96,7 @@ end
 # of the jsonl file, after the line has been decoded
 # into as hashmap.
 def json_from_lines(filename)
-  File.open(filename).each do |line|
+  File.foreach(filename).each do |line|
     yield JSON.parse(line)
   end
 end


### PR DESCRIPTION
Process line by line instead of loading the whole file in memory.

We have no control over the size of the files we're processing, so it's probably a good idea to be defensive here.