### PR TITLE
fix bug on datafile url validation

### DIFF
--- a/lib/validators/url_validator.rb
+++ b/lib/validators/url_validator.rb
@@ -7,7 +7,6 @@ class UrlValidator < ActiveModel::Validator
   def validate(record)
     urlPresent?(record) &&
         urlStartsWithProtocol?(record) &&
-        validDomain?(record) &&
         validPath?(record)
   end
 
@@ -23,17 +22,6 @@ class UrlValidator < ActiveModel::Validator
     error = 'Url does not start with http or https'
 
     record.url !~ /^https?/ ?
-        createValidationError(record, error) :
-        true
-  end
-
-  def validDomain?(record)
-    host = URI.parse(record.url).host
-    domainQuery = Whois.whois(host)
-    parser = domainQuery.parser
-    error = 'Url does not contain a valid domain'
-
-    !parser.registered? ?
         createValidationError(record, error) :
         true
   end

--- a/lib/validators/url_validator.rb
+++ b/lib/validators/url_validator.rb
@@ -29,8 +29,7 @@ class UrlValidator < ActiveModel::Validator
   def validPath?(record)
     begin
       RestClient.head record.url
-      true
-    rescue RestClient::ExceptionWithResponse
+    rescue 
       error = 'Url path is not valid'
       createValidationError(record, error)
     end

--- a/spec/features/edit_dataset_spec.rb
+++ b/spec/features/edit_dataset_spec.rb
@@ -5,7 +5,6 @@ describe 'editing datasets' do
   set_up_models
 
   before(:each) do
-    allow_any_instance_of(UrlValidator).to receive(:validDomain?).and_return(true)
     allow_any_instance_of(UrlValidator).to receive(:validPath?).and_return(true)
     user
     sign_in_user

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    allow_any_instance_of(UrlValidator).to receive(:validDomain?).and_return(true)
     allow_any_instance_of(UrlValidator).to receive(:validPath?).and_return(true)
   end
 

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe UrlValidator do
     describe 'Creates validation errors when' do
 
       before(:each) do
-        allow_any_instance_of(UrlValidator).to receive(:validDomain?).and_call_original
         allow_any_instance_of(UrlValidator).to receive(:validPath?).and_call_original
       end
 


### PR DESCRIPTION
There is a bug on publish where valid url's were failing the `validDomain?` check raising a 'Url does not contain a valid domain' in the console. eg this valid link was failing:
https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/49810/582.xls

I think it was an issue with how we were querying the Whois server.

Removing the validation on domain fixes this bug, and doesn't feel like a bad thing to do as we check url is a valid path via RestClient. Plus the user only sees one error message "Please enter a valid URL" regardless of the underlying error so we aren't depriving them of useful debugging information by removing the check on domain. 