### PR TITLE
Vcap config fix

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -9,7 +9,7 @@ class Dataset < ApplicationRecord
   extend FriendlyId
 
   friendly_id :slug_candidates, :use => :slugged, :slug_column => :name
-  index_name    "datasets-#{Rails.env}"
+  index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
   document_type "dataset"
 
   after_initialize :set_initial_stage

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,5 +1,6 @@
 default: &default
-  host: http://localhost:9200
+  host: <%= ENV["ES_HOST"] || "http://localhost:9200" %>
+  vcap_services: '<%= ENV["VCAP_SERVICES"] %>'
   elastic_timeout: 5
 
 test:
@@ -10,8 +11,6 @@ development:
 
 staging:
   <<: *default
-  host: '<%= ENV["ES_HOST"] %>'
 
 production:
   <<: *default
-  vcap_services: '<%= ENV["VCAP_SERVICES"] %>'

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -10,8 +10,8 @@ development:
 
 staging:
   <<: *default
-  host: <%= ENV['ES_HOST'] %>
+  host: '<%= ENV["ES_HOST"] %>'
 
 production:
   <<: *default
-  vcap_services: <%= ENV['VCAP_SERVICES'] %>
+  vcap_services: '<%= ENV["VCAP_SERVICES"] %>'

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -25,7 +25,7 @@ def create_es_cert_file(cert)
 end
 
 
-def es_config_production
+def es_config_from_vcap
   begin
     vcap = JSON.parse(ELASTIC_CONFIG['vcap_services'])
   rescue => e
@@ -67,7 +67,7 @@ def es_config_production
   }
 end
 
-def es_config_non_production
+def es_config_from_host
   {
     host: ELASTIC_CONFIG['host'],
     transport_options: {
@@ -79,8 +79,8 @@ def es_config_non_production
 end
 
 config = ELASTIC_CONFIG['vcap_services'].present? ?
-            es_config_production :
-            es_config_non_production
+            es_config_from_vcap :
+            es_config_from_host
 
 ELASTIC = Elasticsearch::Client.new(config)
 Elasticsearch::Model.client = ELASTIC

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,5 +1,4 @@
 require 'base64'
-require 'tempfile'
 
 CONFIG_PATH = Rails.root.join('config', 'elasticsearch.yml')
 TEMPLATE = ERB.new File.new(CONFIG_PATH).read
@@ -18,7 +17,7 @@ def log(server, filepath)
 end
 
 def create_es_cert_file(cert)
-  es_cert_file = Tempfile.new('es')
+  es_cert_file = File.new('elasticsearch_cert.pem', 'w')
   es_cert_file.write(cert)
   es_cert_file.close
   es_cert_file

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -41,7 +41,6 @@ def es_config_from_vcap
     Rails.logger.fatal e
     exit
   end
-
   es_cert_file = create_es_cert_file(es_cert)
   log(es_server, es_cert_file.path)
 

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -59,8 +59,9 @@ namespace :search do
                                               type: ::Dataset.__elasticsearch__.document_type,
                                               body: prepare_records(datasets)
                                             })
-    rescue
-      puts "This batch of datasets was too large"
+    rescue => e
+      puts "There was an error uploading datasets:"
+      puts e
     end
   end
 


### PR DESCRIPTION
I think it's more flexible to allow the app to read from VCAP_SERVICES even locally. That way it's possible to access a PaaS elasticsearch server by setting VCAP_SERVICES in your terminal.

Other changes are around better error handling. See respective commits.