### PR TITLE
Remove :published boolean column from datasets table

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -43,7 +43,7 @@ class DatasetsController < ApplicationController
   def publish
     @dataset.complete!
 
-    if @dataset.publishable? # todo move check to Dataset#publish
+    if @dataset.publishable?
       if @dataset.published?
         flash[:success] = I18n.t 'dataset_updated'
       else

--- a/db/migrate/20171006145144_remove_published_from_datasets.rb
+++ b/db/migrate/20171006145144_remove_published_from_datasets.rb
@@ -1,0 +1,5 @@
+class RemovePublishedFromDatasets < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :datasets, :published, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -101,7 +101,6 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.text "frequency"
     t.integer "creator_id"
     t.integer "owner_id"
-    t.boolean "published", default: false, null: false
     t.datetime "published_date"
     t.boolean "harvested"
     t.text "legacy_metadata"


### PR DESCRIPTION
**BEFORE** merging this PR, please make sure you:

* [x] merge https://github.com/datagovuk/publish_data_beta/pull/381
* [x] run task `datasets:migrate_status`

Follows up on https://github.com/datagovuk/publish_data_beta/pull/349.

The migration of the data from the `published` column to the `status` column has run successfully, so we can now safely remove the `:published` boolean column from the `datasets` table.