### PR TITLE
Harvested datasets are readonly

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -34,10 +34,18 @@ class Dataset < ApplicationRecord
   validates :licence, presence: true, if: :published?
   validates :licence_other, presence: true, if: lambda { licence == 'other' }
   validates :stage, inclusion: { in: STAGES }
-  validate :published_dataset_must_have_datafiles_validation
+
+  validate  :published_dataset_must_have_datafiles_validation
+  validate  :is_readonly?, on: :update
 
   scope :owned_by, ->(creator_id) { where(creator_id: creator_id) }
   scope :published, ->{ where(status: "published") }
+
+  def is_readonly?
+    if persisted? && self.harvested?
+      errors[:base] << 'Harvested datasets cannot be modified.'
+    end
+  end
 
   def datafiles
     links + docs

--- a/app/views/datasets/edit.html.erb
+++ b/app/views/datasets/edit.html.erb
@@ -4,22 +4,18 @@
 
 <div class="datasets">
   <% if @dataset.errors.any? %>
-		<div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-			<h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-				There was a problem
-			</h1>
-			<ul class="error-summary-list">
-        <% @dataset.errors.each do |attr, message| %>
-          <li>
-            <a href="#<%= attr.to_s %>_form_group">
-              <%= "Please enter a valid #{attr.to_s.humanize.downcase}" %>
-            </a>
-            <span class="visuallyhidden">.</span>
-          </li>
-				<% end %>
-			</ul>
-		</div>
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        There was a problem
+      </h1>
+      <ul class="error-summary-list">
+        <% @dataset.errors.each do |attr, error| %>
+          <li><a href="#<%= attr.to_s %>_form_group"><%= error %></a></li>
+        <% end %>
+      </ul>
+    </div>
   <% end %>
+
   <h1 class="heading-large">Change your dataset's details</h1>
 
   <%= form_for @dataset, url: dataset_path(@dataset), method: :put do |f| %>

--- a/app/views/manage/_base.html.erb
+++ b/app/views/manage/_base.html.erb
@@ -25,7 +25,7 @@
         <tr>
           <th>
             <% if dataset.published? %>
-              <a href="<%= find_url(dataset.name) %>"><%= dataset.title %></a>
+              <%= link_to dataset.title, find_url(dataset.name) %>
             <% else %>
               <%= dataset.title %>
             <% end %>
@@ -34,7 +34,7 @@
             <%= dataset.status.titleize %>
           </td>
           <td class="dgu-datasets-table__actions">
-            <% if dataset.name %>
+            <% unless dataset.is_readonly? %>
               <%= link_to 'Add Data', links_path(dataset) %>
               <%= link_to 'Edit', dataset_path(dataset) %><br/>
             <% end %>
@@ -43,7 +43,7 @@
       <% end %>
     </tbody>
   </table>
-  <% if @datasets.count == 0 %>
+  <% if @datasets.none? %>
   <p
       class="noresults"
       style="display:<% if @datasets.count %>block<% else %>none<% end %>">

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe DatasetsController, type: :controller do
+  it "prevents harvested datasets from being updated through the user interface" do
+    user = FactoryGirl.create(:user)
+    sign_in(user)
+
+    dataset = FactoryGirl.create(:dataset,
+                                 harvested: true,
+                                 links: [FactoryGirl.create(:link)])
+
+    patch :update, params: { id: dataset.name, dataset: { title: "New title" } }
+
+    dataset.valid?
+
+    expect(dataset.errors[:base]).to include("Harvested datasets cannot be modified.")
+  end
+end

--- a/spec/features/harvested_dataset_spec.rb
+++ b/spec/features/harvested_dataset_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe "Harvested datasets" do
+  let(:land) { FactoryGirl.create(:organisation) }
+  let(:user) { FactoryGirl.create(:user, primary_organisation: land) }
+
+  it "should be readonly (no add/edit buttons appear)" do
+    harvested_dataset = FactoryGirl.create(:dataset,
+                                           organisation: land,
+                                           harvested: true,
+                                           links: [FactoryGirl.create(:link)],
+                                           creator: user,
+                                           owner: user)
+
+    user
+    sign_in_user
+    click_link 'Manage datasets'
+
+    expect(page).to have_content(harvested_dataset.title)
+    expect(page).not_to have_content("Add Data")
+    expect(page).not_to have_content("Edit")
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,4 @@
+RSpec.configure do |config|
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
+end


### PR DESCRIPTION
Each time a dataset is harvested, it is updated in Publish. If a publisher edits a harvested dataset, the changes will be overwritten at the next harvest. To prevent that, we want to make such datasets readonly.

This PR

* checks if dataset is harvested
* hides Add Data and Edit links if dataset is harvested
* aborts update of a harvested dataset and displays error message to the user

Note that the import and sync rake tasks skip validation when updating a dataset, so we're all good on that front.

https://trello.com/c/Fclrjhei/5-harvested-datasets-are-read-only-on-publish-beta

<img width="1030" alt="screen shot 2017-10-11 at 08 39 00" src="https://user-images.githubusercontent.com/3141541/31427585-b9717c48-ae5f-11e7-91fc-f31d38deb432.png">

![screen shot 2017-10-11 at 11 06 10](https://user-images.githubusercontent.com/3141541/31434409-3becfabc-ae74-11e7-9dd1-4ae1e1fd7a5c.png)

This PR prevents harvested datasets from being edited by the user from the UI - i.e. the 'edit' button is hidden in the view and the guard clause is present only in the `update` controller action.

However, a harvested dataset can still be updated programmatically at the model layer level, e.g. with: `harvested_dataset.update(title: "new title")`.

