### PR TITLE
Configure and initialize Sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,15 @@
+REDIS_CONFIG = Rails.application.config_for(:redis)
+
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: "redis://#{REDIS_CONFIG[:host]}:#{REDIS_CONFIG[:port]}/12",
+    password: REDIS_CONFIG[:password]
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: "redis://#{REDIS_CONFIG[:host]}:#{REDIS_CONFIG[:port]}/12",
+    password: REDIS_CONFIG[:password]
+  }
+end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,0 +1,19 @@
+development:
+  host: 'localhost'
+  port: 6379
+
+test:
+  host: 'localhost'
+  port: 6379
+
+staging:
+  host: '<%= ENV['REDIS_IP'] %>'
+  port: '<%= ENV['REDIS_PORT'] %>'
+  password: '<%= ENV['REDIS_PASSWORD'] %>'
+  network_timeout: 5
+
+production:
+  host: '<%= ENV['REDIS_IP'] %>'
+  port: '<%= ENV['REDIS_PORT'] %>'
+  password: '<%= ENV['REDIS_PASSWORD'] %>'
+  network_timeout: 5


### PR DESCRIPTION
Now that we've included the Sidekiq servers in the manifest (https://github.com/datagovuk/publish_data_beta/pull/360), we can configure and initialize Sidekiq for staging and production.