### PR TITLE
Fix Sidekiq config + add timeout option

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,13 +3,15 @@ REDIS_CONFIG = Rails.application.config_for(:redis)
 Sidekiq.configure_server do |config|
   config.redis = {
     url: "redis://#{REDIS_CONFIG['host']}:#{REDIS_CONFIG['port']}/12",
-    password: REDIS_CONFIG['password']
+    password: REDIS_CONFIG['password'],
+    network_timeout: REDIS_CONFIG['network_timeout']
   }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = {
     url: "redis://#{REDIS_CONFIG['host']}:#{REDIS_CONFIG['port']}/12",
-    password: REDIS_CONFIG['password']
+    password: REDIS_CONFIG['password'],
+    network_timeout: REDIS_CONFIG['network_timeout']
   }
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,14 +2,14 @@ REDIS_CONFIG = Rails.application.config_for(:redis)
 
 Sidekiq.configure_server do |config|
   config.redis = {
-    url: "redis://#{REDIS_CONFIG[:host]}:#{REDIS_CONFIG[:port]}/12",
-    password: REDIS_CONFIG[:password]
+    url: "redis://#{REDIS_CONFIG['host']}:#{REDIS_CONFIG['port']}/12",
+    password: REDIS_CONFIG['password']
   }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = {
-    url: "redis://#{REDIS_CONFIG[:host]}:#{REDIS_CONFIG[:port]}/12",
-    password: REDIS_CONFIG[:password]
+    url: "redis://#{REDIS_CONFIG['host']}:#{REDIS_CONFIG['port']}/12",
+    password: REDIS_CONFIG['password']
   }
 end


### PR DESCRIPTION
We are using symbolized instead of quoted keys to grab the configuration values from the yaml file, so values were not showing up. Using stringed keys fixes the issue. Also added network timeout option.

Follows https://github.com/datagovuk/publish_data_beta/pull/361.