### PR TITLE
Fix Find URL on dataset link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,6 @@ module ApplicationHelper
   end
 
   def find_url(dataset_name)
-    "#{ENV['FIND_URL'] || ''}/dataset/#{dataset_name}"
+    "https://#{ENV['FIND_URL'] || ''}/dataset/#{dataset_name}"
   end
 end

--- a/app/views/manage/manage_own.html.erb
+++ b/app/views/manage/manage_own.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-box-highlight">
   <h1 class="bold-large"><%= flash[:success] %></h1>
   <h2>
-    <a href="<%= find_url(flash[:extra]["name"]) %>">View it</a>
+    <%= link_to "View it", find_url(flash[:extra]["name"]) %>
   </h2>
 </div>
 <% end %>


### PR DESCRIPTION
We need to specify the protocol in the `#find_url` helper in order to avoid having Rails insert the protocol + domain of the server the app is currently running on.

This PR fixes the external links to Find: the dataset title in the list of managed datasets, and the _View it_ link that shows in the flash message after a dataset has been published.

![screen shot 2017-10-11 at 17 07 01](https://user-images.githubusercontent.com/3141541/31452991-636eec92-aea8-11e7-8c94-5fa95c0a3fbf.png)
