### PR TITLE
FIX - Legacy Sync

### DIFF
--- a/app/controllers/sync_controller.rb
+++ b/app/controllers/sync_controller.rb
@@ -1,4 +1,5 @@
 require 'rake'
+require './lib/sync/legacy_datasets'
 
 class SyncController < ApplicationController
   def legacy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   get 'tasks', to: 'tasks#my'
   get 'tasks/organisation', to: 'tasks#organisation'
 
-  post 'api/start_legacy_sync', to: 'sync#legacy'
+  get 'api/start_legacy_sync', to: 'sync#legacy'
 
   resources :datasets do
     get 'show/:id', to: 'datasets#show'

--- a/spec/controllers/sync_controller_spec.rb
+++ b/spec/controllers/sync_controller_spec.rb
@@ -4,7 +4,7 @@ require './lib/sync/legacy_datasets'
 describe SyncController, type: :controller do
   it 'invokes the sync legacy dataset rake task' do
     allow_any_instance_of(LegacyDataSync).to receive(:run).and_return true
-    post :legacy
+    get :legacy
     assert_response :success
   end
 end


### PR DESCRIPTION
- Revert POST to GET request to sidestep CSRF error. Not ideal but
hoping this is ok given this is a temporary endpoint with limited
security risks