### PR TITLE
Updates to metadata on publish sent to legacy

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -3,6 +3,10 @@ class DatasetsController < ApplicationController
   before_action :set_dataset, only: [:show, :edit, :update, :destroy,
                                      :publish, :confirm_delete, :quality]
 
+  if Rails.env.production?
+    after_action :update_legacy, only: [:update]
+  end
+
   def show
     @dataset.complete!
   end
@@ -90,5 +94,9 @@ class DatasetsController < ApplicationController
 
   def dataset_params
     params.require(:dataset).permit(:title, :summary, :description)
+  end
+
+  def update_legacy
+    LegacySyncWorker.perform_async(@dataset.id)
   end
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -90,7 +90,7 @@ class Dataset < ApplicationRecord
       unpublished: !publish_json['published'],
       metadata_created: publish_json['created_at'],
       metadata_modified: publish_json['last_updated_at'],
-      geographic_coverage: [publish_json['location1'].downcase],
+      geographic_coverage: [(publish_json['location1'] || "").downcase],
       license_id: publish_json['licence']
     }
     add_custom_freq_key(ckan_json, publish_json)
@@ -106,7 +106,7 @@ class Dataset < ApplicationRecord
         'never' => 'never',
         'discontinued' => 'discontinued',
         'one-off' => 'other'
-    }[frequency]
+    }.fetch(frequency,"")
   end
 
   def add_custom_freq_key(ckan_json, publish_json)

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -17,7 +17,6 @@ class Dataset < ApplicationRecord
   after_initialize :set_initial_stage
   before_destroy :prevent_if_published
   before_save :set_uuid
-  after_save :update_legacy
 
   belongs_to :organisation
   belongs_to :theme, optional: true
@@ -69,10 +68,6 @@ class Dataset < ApplicationRecord
         inspire_dataset: {}
       }
     )
-  end
-
-  def update_legacy
-    LegacySyncWorker.perform_async(self.id)
   end
 
   # map the dataset.as_json so that the keys are in a format that ckan recognises

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -92,15 +92,14 @@ class Dataset < ApplicationRecord
   end
 
   def convert_freq_to_legacy_format(frequency)
-    frequencies = {
-        'annually' => 'annual' ,
-        'quarterly' => 'quarterly',
-        'monthly' => 'monthly',
-        'daily' => 'other',
-        'weekly' => 'other',
-        'never' => 'never',
-        'discontinued' => 'discontinued',
-        'one-off' => 'other'
+    { 'annually' => 'annual' ,
+      'quarterly' => 'quarterly',
+      'monthly' => 'monthly',
+      'daily' => 'other',
+      'weekly' => 'other',
+      'never' => 'never',
+      'discontinued' => 'discontinued',
+      'one-off' => 'other'
     }.fetch(frequency,"")
   end
 

--- a/app/workers/legacy_sync_worker.rb
+++ b/app/workers/legacy_sync_worker.rb
@@ -1,0 +1,15 @@
+require 'rest-client'
+
+class LegacySyncWorker
+  include Sidekiq::Worker
+
+  def perform(id)
+    json = Dataset.find(id).ckanify_metadata.to_json
+    server =
+      Rails.env.production? ? "https://data.gov.uk" : "https://test.data.gov.uk"
+    url = "#{ server }/api/3/action/package_patch"
+    headers = {Authorization: ENV["LEGACY_API_KEY"]}
+    RestClient.post(url,json,headers)
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -192,14 +192,6 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.bigint "user_id", null: false
   end
 
-  create_table "previews", force: :cascade do |t|
-    t.bigint "datafiles_id"
-    t.json "content"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["datafiles_id"], name: "index_previews_on_datafiles_id"
-  end
-
   create_table "quality_scores", force: :cascade do |t|
     t.bigint "organisation_id"
     t.integer "highest", default: 0
@@ -268,7 +260,6 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
   end
 
   add_foreign_key "inspire_datasets", "datasets"
-  add_foreign_key "previews", "datafiles", column: "datafiles_id"
   add_foreign_key "quality_scores", "organisations"
   add_foreign_key "tasks", "organisations"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,15 +33,9 @@ end
 
 # We can create land-registry now, and if we import organisations
 # then they will just update it.
-land_registry = Organisation.new
-land_registry.name = "land-registry"
-land_registry.title = "Land Registry"
-land_registry.save!()
-
-hmrc = Organisation.new
-hmrc.name = "hmrc"
-hmrc.title = "hmrc"
-hmrc.save!()
+land_registry = Organisation.find_by(name: 'land-registry')
+hmrc = Organisation.find_by(name: 'hmrc')
+gds = Organisation.find_by(name: 'government-digital-service')
 
 # Admin
 AdminUser.create!(
@@ -57,7 +51,7 @@ User.create!(
   name: 'Publisher',
   password: 'password',
   password_confirmation: 'password',
-  primary_organisation: land_registry
+  primary_organisation_id: land_registry.id
 )
 
 # HMRC User
@@ -66,7 +60,16 @@ User.create!(
   name: 'HMRC',
   password: 'password',
   password_confirmation: 'password',
-  primary_organisation: hmrc
+  primary_organisation_id: hmrc.id
+)
+
+#GDS User
+User.create!(
+  email: 'gds@example.com',
+  name: 'GDS',
+  password: 'password',
+  'password_confirmation': 'password',
+  primary_organisation_id: gds.id
 )
 
 # Locations

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# !/usr/bin/env bash
 
 print_warning() {
   echo -e "\033[1;33m"$1"\033[00m";
@@ -14,7 +14,7 @@ print_error() {
 
 export SECRET_KEY_BASE="foobar"
 bundle install
-rails db:reset db:migrate db:seed
+rails db:drop db:create db:schema:load
 
 curl -O https://data.gov.uk/data/dumps/data.gov.uk-ckan-meta-data-latest.organizations.jsonl.gz
 curl -O https://data.gov.uk/data/dumps/data.gov.uk-ckan-meta-data-latest.v2.jsonl.gz
@@ -33,5 +33,8 @@ rails import:datasets["data.gov.uk-ckan-meta-data-latest.v2.jsonl"]
 
 print "Cleaning up"
 rm data.gov.uk-ckan-meta-data-latest.organizations.jsonl data.gov.uk-ckan-meta-data-latest.v2.jsonl
+
+#to create users that belong to real organisations
+rails db:seed
 
 print "All done."

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -95,4 +95,35 @@ describe Dataset do
 
     expect(Dataset.count).to eq 0
   end
+
+  it "can ckanify its metadata" do
+
+
+    d = Dataset.new
+    d.title = "This is a dataset"
+    d.name = "this-is-a-dataset"
+    d.summary = "Summary"
+    d.frequency = "annually"
+    d.organisation_id = @org.id
+    d.licence = "uk-ogl"
+    d.save
+
+    ckanified_metadata = {
+    :id => "#{d.uuid}",
+    :name => "this-is-a-dataset",
+    :title =>"This is a dataset",
+    :notes => "Summary",
+    :description => "Summary",
+    :organization => {:name => @org.name},
+    :update_frequency => "annual",
+    :unpublished => true,
+    :metadata_created => d.created_at,
+    :metadata_modified => nil,
+    :geographic_coverage => [""],
+    :license_id => "uk-ogl"
+    }
+
+    expect(d.ckanify_metadata).to eq ckanified_metadata
+  end
+
 end

--- a/spec/workers/legacy_sync_worker.rb
+++ b/spec/workers/legacy_sync_worker.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe LegacySyncWorker, type: :worker do
+  it 'dataset updates on publish are sent to legacy' do
+  end
+end


### PR DESCRIPTION
This PR is part of [this trello card](https://trello.com/c/7XtWXb4p/3-sync-changes-to-existing-datasets-on-publish-to-legacy)

There are three requirements:

- updates to dataset metadata are sent to legacy 
- updates to datafiles are sent to legacy
- creation of new datasets and datafiles are sent to legacy

This PR implements the first requirement. Comments v welcome on how best to test this @govuklaurence ! 

Have also made the users created by seeds.rb belong to real organisations so that their datasets populate the manage_datasets page 