### PR TITLE
Don't deploy specs

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -12,6 +12,7 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 /node_modules/
+/spec/
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb


### PR DESCRIPTION
The end-to-end tests are over 50MB! The entire app is about 200KB. Let's not upload the specs.