### PR TITLE
An unpublished dataset is not necessarily a draft

### DIFF
--- a/app/models/legacy/dataset.rb
+++ b/app/models/legacy/dataset.rb
@@ -15,7 +15,7 @@ class Legacy::Dataset < SimpleDelegator
                     "package_id" => uuid,
                     "value" => convert_freq_to_legacy_format(frequency)}
                   ],
-      "unpublished" => unpublished?(status),
+      "unpublished" => !published?,
       "metadata_created" => created_at,
       "metadata_modified" => last_updated_at,
       "geographic_coverage" => [(location1 || "").downcase],
@@ -40,10 +40,6 @@ class Legacy::Dataset < SimpleDelegator
       ckan_dataset["extras"].push(extra)
     end
     ckan_dataset
-  end
-
-  def unpublished?(string)
-    string == "draft"
   end
 
   def convert_freq_to_legacy_format(frequency)


### PR DESCRIPTION
The day we add another status (like "discarded", for example), this will erroneously return `true`. The only way to tell whether a dataset is unpublished is if its status is anything else than `"published"`.

`!dataset.published?` ensures we identify a dataset as _not published_ regardless of how many new statuses we may add in the future.