### PR TITLE
Build slugs with dataset uuid and title

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -6,6 +6,10 @@ class DatasetsController < ApplicationController
 
   def show
     @dataset.complete!
+
+    if request.path != dataset_path(@dataset)
+      return redirect_to @dataset, status: :moved_permanently
+    end
   end
 
   def new
@@ -87,11 +91,10 @@ class DatasetsController < ApplicationController
   private
 
   def set_dataset
-    @dataset = Dataset.find_by(name: params[:id])
+    @dataset = Dataset.friendly.find(params[:id])
   end
 
   def dataset_params
     params.require(:dataset).permit(:title, :summary, :description)
   end
-
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -10,7 +10,7 @@ class Dataset < ApplicationRecord
   include Elasticsearch::Model
   extend FriendlyId
 
-  friendly_id :slug_candidates, :use => :slugged, :slug_column => :name
+  friendly_id :uuid_and_title, :use => :slugged, :slug_column => :name
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
   document_type "dataset"
 
@@ -94,14 +94,12 @@ class Dataset < ApplicationRecord
     self.creator_id = user.id
   end
 
-  def slug_candidates
-    [:title, :title_and_sequence]
+  def uuid_and_title
+    "#{uuid} #{title}"
   end
 
-  def title_and_sequence
-    slug = title.to_param
-    sequence = Dataset.where("name like ?", "#{slug}-%").count + 2
-    "#{slug}-#{sequence}"
+  def should_generate_new_friendly_id?
+    title_changed?
   end
 
   def publishable?

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -17,7 +17,6 @@ describe DatasetsController, type: :controller do
   end
 
   it "updates legacy when a dataset is updated" do
-
     user =  FactoryGirl.create(:user)
     sign_in(user)
 
@@ -36,7 +35,16 @@ describe DatasetsController, type: :controller do
     expect(WebMock)
       .to have_requested(:post, url)
       .once
-
   end
 
+  it "redirects to slugged URL" do
+    user =  FactoryGirl.create(:user)
+    sign_in(user)
+
+    dataset = FactoryGirl.create(:dataset, links: [FactoryGirl.create(:link)])
+
+    get :show, params: { id: dataset.id }
+
+    expect(response).to redirect_to(dataset_url(dataset))
+  end
 end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -29,22 +29,22 @@ describe Dataset do
     expect(d.save).to eq(false)
   end
 
-  it "can generate unique slugs" do
-    d1 = Dataset.new
-    d1.title = "dataset"
-    d1.summary = "Summary"
-    d1.organisation_id = @org.id
-    d1.frequency = "daily"
-    expect(d1.save).to eq(true)
+  it "generates a unique slug and stores it on the name column" do
+    dataset = FactoryGirl.create(:dataset,
+                                 uuid: 1234,
+                                 title: "My awesome dataset")
 
-    d2 = Dataset.new
-    d2.title = "dataset"
-    d2.summary = "Summary"
-    d2.organisation_id = @org.id
-    d2.frequency = "daily"
-    expect(d2.save).to eq(true)
+    expect(dataset.name).to eq("1234-my-awesome-dataset")
+  end
 
-    expect(d2.name).to eq("dataset-2")
+  it "generates a new slug when the title has changed" do
+    dataset = FactoryGirl.create(:dataset,
+                                 uuid: 1234,
+                                 title: "My awesome dataset")
+
+    dataset.update(title: "My Even Better Dataset")
+
+    expect(dataset.name).to eq("1234-my-even-better-dataset")
   end
 
   it "validates more strictly when publishing" do


### PR DESCRIPTION
Building a dataset's slug with its uuid and parameterized title is both nice to read and unique. This will ensure we avoid any clashes with existing slugs in Legacy.

example slug: `http://foo.com/datasets/ca0902fb-08bb-46f4-8a96-ee8866b9e673-my-dataset`

Trello card: https://trello.com/c/85fqAa19/32-prevent-slug-duplicates-across-legacy-and-beta