### PR TITLE
Fix slug bug on create

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -14,9 +14,8 @@ class Dataset < ApplicationRecord
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
   document_type "dataset"
 
-  after_initialize :set_initial_stage
+  after_initialize :set_initial_stage, :set_uuid
   before_destroy :prevent_if_published
-  before_save :set_uuid
 
   belongs_to :organisation
   belongs_to :theme, optional: true

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -107,7 +107,7 @@ describe "dataset creation" do
       # Ensure the dataset is indexed in Elastic
       client = Dataset.__elasticsearch__.client
       document = client.get({ index: Dataset.index_name, id: Dataset.last.id })
-      expect(document["_source"]["name"]).to eq("my-test-dataset")
+      expect(document["_source"]["name"]).to eq("#{Dataset.last.uuid} #{Dataset.last.title}".parameterize)
     end
   end
 

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -5,13 +5,15 @@ describe Dataset do
   let! (:org)  { @org = Organisation.create!(name: "land-registry", title: "Land Registry") }
 
   it "can create a new dataset" do
-    d = Dataset.new
-    d.title = "This is a dataset"
-    d.summary = "Summary"
-    d.frequency = "daily"
-    d.organisation_id = @org.id
+    d = Dataset.new(
+      title: "This is a dataset",
+      summary: "Summary",
+      frequency: "daily",
+      organisation_id: @org.id
+    )
+
     expect(d.save).to eq(true)
-    expect(d.name).to eq("this-is-a-dataset")
+    expect(d.name).to eq("#{d.uuid} #{d.title}".parameterize)
   end
 
   it "requires a valid title" do
@@ -31,10 +33,9 @@ describe Dataset do
 
   it "generates a unique slug and stores it on the name column" do
     dataset = FactoryGirl.create(:dataset,
-                                 uuid: 1234,
                                  title: "My awesome dataset")
 
-    expect(dataset.name).to eq("1234-my-awesome-dataset")
+    expect(dataset.name).to eq("#{dataset.uuid} #{dataset.title}".parameterize)
   end
 
   it "generates a new slug when the title has changed" do


### PR DESCRIPTION
We were setting the slug before the uuid had been generated, so the slug was showing with no uuid in the slug for new records, even though it did work when updating an existing record.

This PR ensures we set the dataset's `uuid` as soon as it is initialised, which fixes the bug.