### PR TITLE
User read/update permissions for datasets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'kaminari', '~> 1.0.1'
 gem 'rest-client', '~> 2.0.2'
 gem 'mime-types', '~> 3.1'
 gem 'friendly_id', '~> 5.2.1'
-gem 'cancancan', '~> 1.10'
+gem 'cancancan', '~> 2.0'
 gem "elasticsearch", "~> 5.0.4"
 gem "elasticsearch-model", "~> 5.0.1"
 gem "elasticsearch-rails", "~> 5.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       thor (~> 0.19)
     builder (3.2.3)
     byebug (9.0.6)
-    cancancan (1.17.0)
+    cancancan (2.0.0)
     capybara (2.14.3)
       addressable
       mime-types (>= 1.16)
@@ -406,7 +406,7 @@ DEPENDENCIES
   ancestry (~> 3.0.1)
   audited (~> 4.5)
   byebug (~> 9)
-  cancancan (~> 1.10)
+  cancancan (~> 2.0)
   capybara
   codeclimate-test-reporter (~> 1.0.0)
   database_cleaner
@@ -453,4 +453,4 @@ DEPENDENCIES
   whois-parser
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,15 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  rescue_from CanCan::AccessDenied do |exception|
+    respond_to do |format|
+      format.json { head :forbidden, content_type: 'text/html' }
+      format.html { render plain: '403 Forbidden', status: :forbidden }
+      format.js   { head :forbidden, content_type: 'text/html' }
+    end
+  end
 
   if Rails.env.production? || Rails.env.staging?
     http_basic_authenticate_with name: ENV["HTTP_USERNAME"], password: ENV["HTTP_PASSWORD"]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
-  rescue_from CanCan::AccessDenied do |exception|
+  rescue_from CanCan::AccessDenied do
     respond_to do |format|
       format.json { head :forbidden, content_type: 'text/html' }
       format.html { render plain: '403 Forbidden', status: :forbidden }

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -5,6 +5,7 @@ class DatasetsController < ApplicationController
                                      :publish, :confirm_delete, :quality]
 
   def show
+    authorize!(:read, @dataset)
     @dataset.complete!
 
     if request.path != dataset_path(@dataset)
@@ -17,6 +18,7 @@ class DatasetsController < ApplicationController
   end
 
   def edit
+    authorize!(:update, @dataset)
   end
 
   def create

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,31 +3,9 @@ class Ability
 
   def initialize(user)
     user ||= User.new
-    if user.admin?
-      can :manage, :all
+
+    can [:read, :update], Dataset do |dataset|
+      user.creator_of_dataset?(dataset) || user.in_organisation?(dataset.organisation)
     end
-
-    # Publishers can always create a dataset
-    can :create, Dataset
-
-    can :read, Dataset do |dataset|
-      # User can read a dataset if they are a creator, or
-      # in an organisation shared by the dataset
-      user.id == dataset.creator_id ||
-        user.in_organisation(dataset.organisation)
-    end
-
-    can :update, Dataset do |dataset|
-      # User can update a dataset if they are a creator, or
-      # in an organisation shared by the dataset
-      user.id == dataset.creator_id ||
-        user.in_organisation(dataset.organisation)
-    end
-
-    can :delete, Dataset do |_|
-      # Only sysadmins should be able to delete datasets
-      user.admin?
-    end
-
   end
 end

--- a/app/models/legacy/server.rb
+++ b/app/models/legacy/server.rb
@@ -26,5 +26,4 @@ class Legacy::Server
   def headers
     { Authorization: ENV['LEGACY_API_KEY'] }
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,17 @@ class User < ApplicationRecord
 
   audited
 
-  def in_organisation(organisation)
-    self.primary_organisation == organisation ||
-      self.organisations.include?(organisation)
+  def in_organisation?(organisation)
+    user_organisations.include?(organisation)
+  end
+
+  def creator_of_dataset?(dataset)
+    id == dataset.creator_id
+  end
+
+  private
+
+  def user_organisations
+    organisations + [primary_organisation]
   end
 end

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -18,16 +18,16 @@ describe DatasetsController, type: :controller do
 
   it "updates legacy when a dataset is updated" do
     user =  FactoryGirl.create(:user)
-    sign_in(user)
+    dataset = FactoryGirl.create(:dataset, links: [FactoryGirl.create(:link)])
 
-    dataset = FactoryGirl.create(:dataset,
-                                  links: [FactoryGirl.create(:link)])
+    sign_in(user)
 
     url = "https://test.data.gov.uk/api/3/action/package_patch"
 
     stub_request(:any, url).to_return(status: 200)
 
     patch :update, params: { id: dataset.name, dataset: { title: "New title" } }
+
     dataset.reload
 
     expect(dataset.title).to eq("New title")
@@ -39,12 +39,57 @@ describe DatasetsController, type: :controller do
 
   it "redirects to slugged URL" do
     user =  FactoryGirl.create(:user)
-    sign_in(user)
+    organisation = FactoryGirl.create(:organisation, users: [user])
+    dataset = FactoryGirl.create(:dataset,
+                                 organisation: organisation,
+                                 links: [FactoryGirl.create(:link)])
 
-    dataset = FactoryGirl.create(:dataset, links: [FactoryGirl.create(:link)])
+    sign_in(user)
 
     get :show, params: { id: dataset.id }
 
     expect(response).to redirect_to(dataset_url(dataset))
+  end
+
+  it "returns '503 forbidden' error if a user is not allowed to view the requested dataset" do
+    user = FactoryGirl.create(:user)
+    organisation = FactoryGirl.create(:organisation, users: [user])
+
+    another_organisation = FactoryGirl.create(:organisation)
+
+    allowed_dataset = FactoryGirl.create(:dataset,
+                                 organisation: organisation,
+                                 links: [FactoryGirl.create(:link)])
+
+    forbidden_dataset = FactoryGirl.create(:dataset,
+                                 organisation: another_organisation,
+                                 links: [FactoryGirl.create(:link)])
+
+    sign_in(user)
+
+    get :show, params: { id: forbidden_dataset.id }
+
+    expect(response).to have_http_status(403)
+  end
+
+  it "returns '503 forbidden' error if a user is not allowed to update the requested dataset" do
+    user = FactoryGirl.create(:user)
+    organisation = FactoryGirl.create(:organisation, users: [user])
+
+    another_organisation = FactoryGirl.create(:organisation)
+
+    allowed_dataset = FactoryGirl.create(:dataset,
+                                 organisation: organisation,
+                                 links: [FactoryGirl.create(:link)])
+
+    forbidden_dataset = FactoryGirl.create(:dataset,
+                                 organisation: another_organisation,
+                                 links: [FactoryGirl.create(:link)])
+
+    sign_in(user)
+
+    get :edit, params: { id: forbidden_dataset.id }
+
+    expect(response).to have_http_status(403)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,11 +30,10 @@ describe User do
     u.organisations << org3
     expect(u.organisations.count()).to eq(2)
 
-    expect(u.in_organisation org).to eq(true)
-    expect(u.in_organisation org2).to eq(true)
-    expect(u.in_organisation org3).to eq(true)
+    expect(u.in_organisation?(org)).to eq(true)
+    expect(u.in_organisation?(org2)).to eq(true)
+    expect(u.in_organisation?(org3)).to eq(true)
 
-    expect(u.in_organisation org_private).to eq(false)
-
+    expect(u.in_organisation?(org_private)).to eq(false)
   end
 end


### PR DESCRIPTION
Currently, any dataset can be read and edited by any user. This PR makes sure only users with the following characteristics can view or edit a given dataset:

* user belongs to the organisation that owns the dataset
* user's primary organisation owns the dataset

Trello card: https://trello.com/c/7bSWFsV4/43-on-publish-beta-a-user-can-only-a-edit-dataset-that-they-have-permission-to-edit

Uses the CanCanCan gem: https://github.com/CanCanCommunity/cancancan