### PR TITLE
Keep track of slug history to redirect to latest URL

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -16,7 +16,7 @@ class Dataset < ApplicationRecord
   include Elasticsearch::Model
   extend FriendlyId
 
-  friendly_id :uuid_and_title, :use => :slugged, :slug_column => :name
+  friendly_id :uuid_and_title, use: :history, slug_column: :name
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
   document_type "dataset"
 

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,92 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20171023155727_create_friendly_id_slugs.rb
+++ b/db/migrate/20171023155727_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.1]
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,6 +115,18 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end
 
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+  end
+
   create_table "inspire_datasets", force: :cascade do |t|
     t.string "bbox_east_long"
     t.string "bbox_west_long"

--- a/spec/features/dataset_slug_spec.rb
+++ b/spec/features/dataset_slug_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe 'dataset slug' do
+  it "redirects a URL with an old slug to the URL with the latest slug" do
+    url = "https://test.data.gov.uk/api/3/action/package_patch"
+    stub_request(:any, url).to_return(status: 200)
+
+    organisation = FactoryGirl.create(:organisation)
+    user = FactoryGirl.create(:user, primary_organisation: organisation)
+    dataset = FactoryGirl.create(:dataset,
+                                 title: "foo",
+                                 uuid: "1234",
+                                 organisation: organisation,
+                                 status: "published",
+                                 links: [FactoryGirl.create(:link)],
+                                 creator: user,
+                                 owner: user)
+
+    sign_in_user
+
+    visit dataset_url(dataset)
+    expect(current_path).to eq "/datasets/1234-foo"
+
+    visit edit_dataset_url(dataset)
+    fill_in 'dataset[title]', with: 'bar'
+    click_button 'Save and continue'
+
+    visit "/datasets/1234-foo"
+    expect(current_path).to eq "/datasets/1234-bar"
+  end
+end
+

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -41,6 +41,7 @@ describe Dataset do
   it "generates a new slug when the title has changed" do
     url = "https://test.data.gov.uk/api/3/action/package_patch"
     stub_request(:any, url).to_return(status: 200)
+
     dataset = FactoryGirl.create(:dataset,
                                  uuid: 1234,
                                  title: "My awesome dataset")
@@ -82,7 +83,7 @@ describe Dataset do
   it "is not possible to delete a published dataset" do
     url = "https://test.data.gov.uk/api/3/action/package_patch"
     stub_request(:any, url).to_return(status: 200)
-    
+
     d = Dataset.new(
       title: "dataset",
       summary: "Summary",


### PR DESCRIPTION
As it is, changing the title of a dataset modifies the dataset's slug. Which means we break any external links pointing to the old URL.

This PR introduces the `history` functionality of the FriendlyId gem. It keeps track of the previous versions of slugs in a dedicated table, which allows us to redirect any broken links to the latest version of the URL.

--

https://trello.com/c/bTQ1Nspf/48-in-publish-beta-redirect-dataset-urls-with-old-slugs-to-the-latest-version-the-url-in-order-to-avoid-broken-links-when-a-dataset

http://norman.github.io/friendly_id/file.Guide.html#History__Avoiding_404_s_When_Slugs_Change