### PR TITLE
Store legacy dataset name on publish beta dataset

### DIFF
--- a/app/models/legacy/dataset.rb
+++ b/app/models/legacy/dataset.rb
@@ -1,10 +1,9 @@
 class Legacy::Dataset < SimpleDelegator
 
   def metadata_json
-    organisation = Organisation.find(organisation_id)
     ckan_dataset = {
       "id" => uuid,
-      "name" => name,
+      "name" => legacy_name,
       "title" => title,
       "notes" => summary,
       "description" => summary,

--- a/db/migrate/20171024135704_add_legacy_name_to_dataset.rb
+++ b/db/migrate/20171024135704_add_legacy_name_to_dataset.rb
@@ -1,0 +1,5 @@
+class AddLegacyNameToDataset < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :legacy_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.integer "secondary_theme_id"
     t.datetime "last_updated_at"
     t.integer "status", default: 0
+    t.string "legacy_name"
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end
 

--- a/lib/util/metadata_tools.rb
+++ b/lib/util/metadata_tools.rb
@@ -2,7 +2,7 @@ module MetadataTools
 
   def add_dataset_metadata(obj, orgs_cache, theme_cache)
     d = Dataset.find_or_create_by(uuid: obj["id"])
-    d.name = obj["name"]
+    d.legacy_name = obj["name"]
     d.title = obj["title"]
     d.summary = generate_summary(obj["notes"])
     d.description = obj["notes"]

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     organisation
     title "Price paid for dragon glass"
     summary "All transactions for dragon glass"
+    legacy_name "ye-olde-slug"
     location1 "Westeros"
     frequency "never"
     licence "uk-ogl"


### PR DESCRIPTION
This makes sure we can:

* redirect any links to legacy to its new URL in the new Publish app
* avoid overwriting the names (slugs) in legacy, which breaks links