### PR TITLE
Homemade slugs with custom routes

### DIFF
--- a/app/controllers/datasets/docs_controller.rb
+++ b/app/controllers/datasets/docs_controller.rb
@@ -14,7 +14,7 @@ class Datasets::DocsController < ApplicationController
     @doc = @dataset.docs.build(doc_params)
 
     if @doc.save
-      redirect_to dataset_docs_path(@dataset)
+      redirect_to dataset_docs_path(@dataset.uuid, @dataset.name)
     else
       render :new
     end
@@ -25,7 +25,7 @@ class Datasets::DocsController < ApplicationController
 
   def update
     if @doc.update(doc_params)
-      redirect_to dataset_docs_path(@dataset)
+      redirect_to dataset_docs_path(@dataset.uuid, @dataset.name)
     else
       render :edit
     end
@@ -35,20 +35,20 @@ class Datasets::DocsController < ApplicationController
     flash[:alert] = "Are you sure you want to delete ‘#{@doc.name}’?"
     flash[:doc_id] = @doc.id
 
-    redirect_to dataset_docs_path(@dataset)
+    redirect_to dataset_docs_path(@dataset.uuid, @dataset.name)
   end
 
   def destroy
     flash[:deleted] = "Your link ‘#{@doc.name}’ has been deleted"
     @doc.destroy
 
-    redirect_to dataset_docs_path(@dataset)
+    redirect_to dataset_docs_path(@dataset.uuid, @dataset.name)
   end
 
   private
 
   def set_dataset
-    @dataset = Dataset.find_by(name: params[:dataset_id]) || Dataset.find(params[:dataset_id])
+    @dataset = Dataset.find_by(uuid: params[:uuid])
   end
 
   def set_doc

--- a/app/controllers/datasets/frequencies_controller.rb
+++ b/app/controllers/datasets/frequencies_controller.rb
@@ -21,7 +21,7 @@ class Datasets::FrequenciesController < ApplicationController
     end
 
     if @dataset.save
-      redirect_to new_dataset_link_path(@dataset)
+      redirect_to new_dataset_link_path(@dataset.uuid, @dataset.name)
     else
       render :new
     end
@@ -32,7 +32,7 @@ class Datasets::FrequenciesController < ApplicationController
     @dataset.frequency = params.require(:dataset).permit(:frequency)[:frequency]
 
     if @dataset.save
-      redirect_to dataset_path(@dataset)
+      redirect_to dataset_path(@dataset.uuid, @dataset.name)
     else
       render :edit
     end
@@ -41,6 +41,6 @@ class Datasets::FrequenciesController < ApplicationController
   private
 
   def current_dataset
-    Dataset.find_by(name: params[:dataset_id])
+    Dataset.find_by(uuid: params[:uuid])
   end
 end

--- a/app/controllers/datasets/licences_controller.rb
+++ b/app/controllers/datasets/licences_controller.rb
@@ -14,7 +14,7 @@ class Datasets::LicencesController < ApplicationController
     @dataset.update_attributes(params.require(:dataset).permit(:licence, :licence_other))
 
     if @dataset.save
-      redirect_to new_dataset_location_path(@dataset)
+      redirect_to new_dataset_location_path(@dataset.uuid, @dataset.name)
     else
       render :new
     end
@@ -25,7 +25,7 @@ class Datasets::LicencesController < ApplicationController
     @dataset.update_attributes(params.require(:dataset).permit(:licence, :licence_other))
 
     if @dataset.save
-      redirect_to dataset_path(@dataset)
+      redirect_to dataset_path(@dataset.uuid, @dataset.name)
     else
       render :edit
     end
@@ -34,6 +34,6 @@ class Datasets::LicencesController < ApplicationController
   private
 
   def current_dataset
-    Dataset.find_by(name: params[:dataset_id])
+    Dataset.find_by(uuid: params[:uuid])
   end
 end

--- a/app/controllers/datasets/links_controller.rb
+++ b/app/controllers/datasets/links_controller.rb
@@ -15,7 +15,7 @@ class Datasets::LinksController < ApplicationController
     @link = @dataset.links.build(link_params)
 
     if @link.save
-      redirect_to dataset_links_path(@dataset)
+      redirect_to dataset_links_path(@dataset.uuid, @dataset.name)
     else
       render :new
     end
@@ -26,7 +26,7 @@ class Datasets::LinksController < ApplicationController
 
   def update
     if @link.update(link_params)
-      redirect_to dataset_links_path(@dataset)
+      redirect_to dataset_links_path(@dataset.uuid, @dataset.name)
     else
       render :edit
     end
@@ -36,20 +36,20 @@ class Datasets::LinksController < ApplicationController
     flash[:alert] = "Are you sure you want to delete ‘#{@link.name}’?"
     flash[:link_id] = @link.id
 
-    redirect_to dataset_links_path(@dataset)
+    redirect_to dataset_links_path(@dataset.uuid, @dataset.name)
   end
 
   def destroy
     flash[:deleted] = "Your link ‘#{@link.name}’ has been deleted"
     @link.destroy
 
-    redirect_to dataset_links_path(@dataset)
+    redirect_to dataset_links_path(@dataset.uuid, @dataset.name)
   end
 
   private
 
   def set_dataset
-    @dataset = Dataset.find_by(name: params[:dataset_id]) || Dataset.find(params[:dataset_id])
+    @dataset = Dataset.find_by(uuid: params[:uuid])
   end
 
   def set_link

--- a/app/controllers/datasets/locations_controller.rb
+++ b/app/controllers/datasets/locations_controller.rb
@@ -15,7 +15,7 @@ class Datasets::LocationsController < ApplicationController
     @dataset.update_attributes(location_params)
 
     if @dataset.save
-      redirect_to new_dataset_frequency_path(@dataset)
+      redirect_to new_dataset_frequency_path(@dataset.uuid, @dataset.name)
     else
       render :new
     end
@@ -27,7 +27,7 @@ class Datasets::LocationsController < ApplicationController
     @dataset.update_attributes(location_params)
 
     if @dataset.save
-      redirect_to dataset_path(@dataset)
+      redirect_to dataset_path(@dataset.uuid, @dataset.name)
     else
       render :edit
     end
@@ -36,6 +36,6 @@ class Datasets::LocationsController < ApplicationController
   private
 
   def current_dataset
-    Dataset.find_by(name: params[:dataset_id])
+    Dataset.find_by(uuid: params[:uuid])
   end
 end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -103,6 +103,6 @@ class DatasetsController < ApplicationController
   end
 
   def newest_dataset_path
-    "/datasets/#{@dataset.uuid}/#{@dataset.name}"
+    dataset_path(@dataset.uuid, @dataset.name)
   end
 end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -7,8 +7,8 @@ class DatasetsController < ApplicationController
     authorize!(:read, @dataset)
     @dataset.complete!
 
-    if request.path != dataset_path(@dataset)
-      return redirect_to @dataset, status: :moved_permanently
+    if request_to_outdated_url?
+      return redirect_to newest_dataset_path, status: :moved_permanently
     end
   end
 
@@ -26,7 +26,7 @@ class DatasetsController < ApplicationController
     @dataset.organisation = current_user.primary_organisation
 
     if @dataset.save
-      redirect_to new_dataset_licence_path(@dataset)
+      redirect_to new_dataset_licence_path(@dataset.uuid, @dataset.name)
     else
       render :new
     end
@@ -34,7 +34,7 @@ class DatasetsController < ApplicationController
 
   def update
     if @dataset.update(dataset_params)
-      redirect_to @dataset
+      redirect_to dataset_path(@dataset.uuid, @dataset.name)
     else
       render :edit
     end
@@ -91,10 +91,18 @@ class DatasetsController < ApplicationController
   private
 
   def set_dataset
-    @dataset = Dataset.friendly.find(params[:id])
+    @dataset = Dataset.find_by!(uuid: params[:uuid])
   end
 
   def dataset_params
     params.require(:dataset).permit(:title, :summary, :description)
+  end
+
+  def request_to_outdated_url?
+    request.path != newest_dataset_path
+  end
+
+  def newest_dataset_path
+    "/datasets/#{@dataset.uuid}/#{@dataset.name}"
   end
 end

--- a/app/views/datasets/docs/edit.html.erb
+++ b/app/views/datasets/docs/edit.html.erb
@@ -24,7 +24,7 @@
 
   <h1 class="heading-large">Add a link to supporting documents</h1>
 
-  <%= form_for @doc, url: dataset_doc_path(@dataset, @doc), method: 'put' do |f| %>
+  <%= form_for @doc, url: update_dataset_doc_path(@dataset.uuid, @dataset.name, @doc.id), method: :put do |f| %>
     <%= dataset_field f, @doc,
     name: 'url',
     label: 'URL',
@@ -43,7 +43,7 @@
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %></p>
       <p>
-        <%= link_to 'Cancel', dataset_path(@dataset) %>
+        <%= link_to 'Cancel', dataset_path(@dataset.uuid, @dataset.name) %>
       </p>
     </div>
   <% end %>

--- a/app/views/datasets/docs/edit.html.erb
+++ b/app/views/datasets/docs/edit.html.erb
@@ -24,7 +24,7 @@
 
   <h1 class="heading-large">Add a link to supporting documents</h1>
 
-  <%= form_for @doc, url: update_dataset_doc_path(@dataset.uuid, @dataset.name, @doc.id), method: :put do |f| %>
+  <%= form_for @doc, url: update_dataset_doc_path(@dataset.uuid, @dataset.name, @doc.id) do |f| %>
     <%= dataset_field f, @doc,
     name: 'url',
     label: 'URL',

--- a/app/views/datasets/docs/index.html.erb
+++ b/app/views/datasets/docs/index.html.erb
@@ -9,11 +9,11 @@
         <% if flash[:alert] %>
           <h1 class="heading-medium error-summary-heading"><%= flash[:alert] %></h1>
             <%= link_to "Yes, delete this link",
-                dataset_doc_path(@dataset, flash[:doc_id]),
+                delete_dataset_doc_path(@dataset.uuid, @dataset.name, flash[:doc_id]),
                 method: :delete,
                 class: 'button confirm-delete-box__button'
             %>
-            <%= link_to "Cancel", dataset_docs_path(@dataset), class: 'secondary-button' %>
+            <%= link_to "Cancel", dataset_docs_path(@dataset.uuid, @dataset.name), class: 'secondary-button' %>
           <% end %>
 
           <% if flash[:deleted] %>
@@ -39,8 +39,8 @@
           <th><a href="<%= doc.url %>"><%= doc.name %></a></th>
           <td>✔</td>
           <td class="actions">
-            <%= link_to 'Edit', edit_dataset_doc_path(@dataset, doc.id) %>
-            <%= link_to 'Delete', confirm_delete_dataset_doc_path(@dataset, doc.id) %>
+            <%= link_to 'Edit', edit_dataset_doc_path(@dataset.uuid, @dataset.name, doc.id) %>
+            <%= link_to 'Delete', confirm_delete_dataset_doc_path(@dataset.uuid, @dataset.name, doc.id) %>
           </td>
         </tr>
       <% end %>
@@ -52,6 +52,6 @@
   </p>
 
   <p>
-    <%= link_to 'Save and continue', dataset_path(@dataset), class: "button" %>
+    <%= link_to 'Save and continue', dataset_path(@dataset.uuid, @dataset.name), class: "button" %>
   </p>
 </main>

--- a/app/views/datasets/docs/index.html.erb
+++ b/app/views/datasets/docs/index.html.erb
@@ -48,7 +48,7 @@
   </table>
 
   <p>
-    <%= link_to 'Add another link', new_dataset_doc_path(@dataset), class: "secondary-button" %>
+    <%= link_to 'Add another link', new_dataset_doc_path(@dataset.uuid, @dataset.name), class: "secondary-button" %>
   </p>
 
   <p>

--- a/app/views/datasets/docs/new.html.erb
+++ b/app/views/datasets/docs/new.html.erb
@@ -24,7 +24,7 @@
 
   <h1 class="heading-large">Add a link to supporting documents</h1>
 
-  <%= form_for @doc, url: dataset_docs_path(@dataset), method: 'post' do |f| %>
+  <%= form_for @doc, url: dataset_docs_path(@dataset.uuid, @dataset.name), method: :post do |f| %>
     <%= dataset_field f, @doc,
     name: 'url',
     label: 'URL',
@@ -43,7 +43,7 @@
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %></p>
       <p>
-        <%= link_to 'Skip this step', dataset_path(@dataset) %>
+        <%= link_to 'Skip this step', dataset_path(@dataset.uuid, @dataset.name) %>
       </p>
     </div>
   <% end %>

--- a/app/views/datasets/edit.html.erb
+++ b/app/views/datasets/edit.html.erb
@@ -18,7 +18,7 @@
 
   <h1 class="heading-large">Change your dataset's details</h1>
 
-  <%= form_for @dataset, url: dataset_path(@dataset), method: :put do |f| %>
+  <%= form_for @dataset, url: update_dataset_path(@dataset.uuid, @dataset.name) do |f| %>
 
     <%= dataset_field f, @dataset,
     input_type: :text_field,

--- a/app/views/datasets/frequencies/edit.html.erb
+++ b/app/views/datasets/frequencies/edit.html.erb
@@ -22,7 +22,7 @@
   <% end %>
   <h1 class="heading-large">How frequently is this dataset updated?</h1>
 
-  <%= form_for @dataset, url: dataset_frequency_path(@dataset), method: :put do |f| %>
+  <%= form_for @dataset, url: update_dataset_frequency_path(@dataset.uuid, @dataset.name) do |f| %>
     <div class="form-group">
       <fieldset>
         <legend class="visually-hidden">How frequently is this dataset updated?</legend>

--- a/app/views/datasets/frequencies/new.html.erb
+++ b/app/views/datasets/frequencies/new.html.erb
@@ -22,7 +22,7 @@
   <% end %>
   <h1 class="heading-large">How frequently is this dataset updated?</h1>
 
-  <%= form_for @dataset, url: dataset_frequency_path(@dataset), method: :post do |f| %>
+  <%= form_for @dataset, url: create_dataset_frequency_path(@dataset.uuid, @dataset.name), method: :post do |f| %>
     <div class="form-group <% if @dataset.errors.key? "frequency" %>form-group-error<%end%>">
       <fieldset>
         <legend id="#id_frequency">

--- a/app/views/datasets/licences/edit.html.erb
+++ b/app/views/datasets/licences/edit.html.erb
@@ -4,11 +4,11 @@
 
 <div class="datasets">
   <% if @dataset.errors.any? %>
-		<div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-			<h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-				There was a problem
-			</h1>
-			<ul class="error-summary-list">
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        There was a problem
+      </h1>
+      <ul class="error-summary-list">
         <% @dataset.errors.each do |attr, message| %>
           <li>
             <a href="#<%= attr.to_s %>_form_group">
@@ -16,13 +16,13 @@
             </a>
             <span class="visuallyhidden">.</span>
           </li>
-				<% end %>
-			</ul>
-		</div>
+        <% end %>
+      </ul>
+    </div>
   <% end %>
   <h1 class="heading-large">Choose a licence for this dataset</h1>
 
-  <%= form_for @dataset, url: dataset_licence_path(@dataset), method: :put do |f| %>
+  <%= form_for @dataset, url: update_dataset_licence_path(@dataset.uuid, @dataset.name) do |f| %>
     <div class="form-group">
       <fieldset>
         <legend class="visually-hidden">Choose a licence for this dataset</legend>
@@ -51,7 +51,7 @@
 
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %> </br></p>
-      <p><%= link_to 'Cancel', dataset_path(@dataset) %></p>
+      <p><%= link_to 'Cancel', dataset_path(@dataset.uuid, @dataset.name) %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/datasets/licences/new.html.erb
+++ b/app/views/datasets/licences/new.html.erb
@@ -4,11 +4,11 @@
 
 <div class="datasets">
   <% if @dataset.errors.any? %>
-		<div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-			<h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-				There was a problem
-			</h1>
-			<ul class="error-summary-list">
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        There was a problem
+      </h1>
+      <ul class="error-summary-list">
         <% @dataset.errors.each do |attr, message| %>
           <li>
             <a href="#id_<%= attr.to_s %>">
@@ -16,14 +16,14 @@
             </a>
             <span class="visuallyhidden">.</span>
           </li>
-				<% end %>
-			</ul>
-		</div>
+        <% end %>
+      </ul>
+    </div>
   <% end %>
 
   <h1 class="heading-large">Choose a licence for this dataset</h1>
 
-  <%= form_for @dataset, url: dataset_licence_path(@dataset), method: :post do |f| %>
+  <%= form_for @dataset, url: create_dataset_licence_path(@dataset.uuid, @dataset.name), method: :post do |f| %>
     <div class="form-group">
       <fieldset>
         <legend class="visually-hidden">Choose a licence for this dataset</legend>
@@ -52,7 +52,7 @@
 
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %> </br></p>
-      <p><%= link_to 'Skip this step', new_dataset_location_path(@dataset) %></p>
+      <p><%= link_to 'Skip this step', new_dataset_location_path(@dataset.uuid, @dataset.name) %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/datasets/links/edit.html.erb
+++ b/app/views/datasets/links/edit.html.erb
@@ -24,7 +24,7 @@
 
   <h1 class="heading-large">Add a link to your data</h1>
 
-  <%= form_for @link, url: update_dataset_link_path(@dataset.uuid, @dataset.name), method: :put do |f| %>
+  <%= form_for @link, url: update_dataset_link_path(@dataset.uuid, @dataset.name) do |f| %>
     <%= dataset_field f, @link,
     name: 'url',
     label: 'URL',

--- a/app/views/datasets/links/edit.html.erb
+++ b/app/views/datasets/links/edit.html.erb
@@ -24,7 +24,7 @@
 
   <h1 class="heading-large">Add a link to your data</h1>
 
-  <%= form_for @link, url: dataset_link_path(@dataset, file: @link), method: :put do |f| %>
+  <%= form_for @link, url: update_dataset_link_path(@dataset.uuid, @dataset.name), method: :put do |f| %>
     <%= dataset_field f, @link,
     name: 'url',
     label: 'URL',
@@ -61,7 +61,7 @@
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %></p>
       <p>
-      <%= link_to 'Cancel', dataset_path(@dataset) %>
+      <%= link_to 'Cancel', dataset_path(@dataset.uuid, @dataset.name) %>
       </p>
     </div>
   <% end %>

--- a/app/views/datasets/links/index.html.erb
+++ b/app/views/datasets/links/index.html.erb
@@ -9,11 +9,11 @@
         <% if flash[:alert] %>
           <h1 class="heading-medium error-summary-heading"><%= flash[:alert] %></h1>
             <%= link_to "Yes, delete this link",
-                dataset_link_path(@dataset, flash[:link_id]),
+                delete_dataset_link_path(@dataset.uuid, @dataset.name, flash[:link_id]),
                 method: :delete,
                 class: 'button confirm-delete-box__button'
             %>
-            <%= link_to "Cancel", dataset_links_path(@dataset), class: 'secondary-button' %>
+            <%= link_to "Cancel", dataset_links_path(@dataset.uuid, @dataset.name), class: 'secondary-button' %>
           <% end %>
 
           <% if flash[:deleted] %>
@@ -39,8 +39,8 @@
           <th><a href="<%= link.url %>"><%= link.name %></a></th>
           <td>✔</td>
           <td class="actions">
-            <%= link_to 'Edit', edit_dataset_link_path(@dataset, link.id) %>
-            <%= link_to 'Delete', confirm_delete_dataset_link_path(@dataset, link.id) %>
+            <%= link_to 'Edit', edit_dataset_link_path(@dataset.uuid, @dataset.name, link.id) %>
+            <%= link_to 'Delete', confirm_delete_dataset_link_path(@dataset.uuid, @dataset.name, link.id) %>
           </td>
         </tr>
       <% end %>
@@ -48,14 +48,14 @@
   </table>
 
   <p>
-    <%= link_to 'Add another link', new_dataset_link_path(@dataset), class: "secondary-button" %>
+    <%= link_to 'Add another link', new_dataset_link_path(@dataset.uuid, @dataset.name), class: "secondary-button" %>
   </p>
 
   <p>
     <% if @dataset.initialised? %>
-      <%= link_to 'Save and continue', new_dataset_doc_path(@dataset), class: "button" %>
+      <%= link_to 'Save and continue', new_dataset_doc_path(@dataset.uuid, @dataset.name), class: "button" %>
     <% else %>
-      <%= link_to 'Save and continue', dataset_path(@dataset), class: "button" %>
+      <%= link_to 'Save and continue', dataset_path(@dataset.uuid, @dataset.name), class: "button" %>
     <% end %>
   </p>
 

--- a/app/views/datasets/links/new.html.erb
+++ b/app/views/datasets/links/new.html.erb
@@ -24,7 +24,7 @@
 
   <h1 class="heading-large">Add a link to your data</h1>
 
-  <%= form_for @link, url: dataset_links_path(@dataset, file: @link), method: 'post' do |f| %>
+  <%= form_for @link, url: dataset_links_path(@dataset.uuid, @dataset.name), method: :post do |f| %>
     <%= dataset_field f, @link,
     name: 'url',
     label: 'URL',
@@ -61,7 +61,7 @@
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %></p>
       <p>
-        <%= link_to 'Skip this step', new_dataset_doc_path(@dataset) %>
+        <%= link_to 'Skip this step', new_dataset_doc_path(@dataset.uuid, @dataset.name) %>
       </p>
     </div>
   <% end %>

--- a/app/views/datasets/locations/edit.html.erb
+++ b/app/views/datasets/locations/edit.html.erb
@@ -22,7 +22,7 @@
 
 <h1 class="heading-large">Choose a geographical area</h1>
 
-<%= form_for @dataset, url: dataset_location_path(@dataset), method: :put do |f| %>
+<%= form_for @dataset, url: update_dataset_location_path(@dataset.uuid, @dataset.name) do |f| %>
   <fieldset>
     <legend class="visually-hidden">
       Choose a geographical area
@@ -69,5 +69,5 @@
 
   </fieldset>
   <p><%= f.submit 'Save and continue', class: 'button' %></p>
-  <p><%= link_to 'Cancel', dataset_path(@dataset) %></p>
+  <p><%= link_to 'Cancel', dataset_path(@dataset.uuid, @dataset.name) %></p>
 <% end %>

--- a/app/views/datasets/locations/new.html.erb
+++ b/app/views/datasets/locations/new.html.erb
@@ -22,7 +22,7 @@
 
 <h1 class="heading-large">Choose a geographical area</h1>
 
-<%= form_for @dataset, url: dataset_location_path(@dataset), method: :post do |f| %>
+<%= form_for @dataset, url: create_dataset_location_path(@dataset.uuid, @dataset.name), method: :post do |f| %>
   <fieldset>
     <legend class="visually-hidden">
       Choose a geographical area

--- a/app/views/datasets/new.html.erb
+++ b/app/views/datasets/new.html.erb
@@ -4,11 +4,11 @@
 
 <div class="datasets">
   <% if @dataset.errors.any? %>
-		<div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-			<h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-				There was a problem
-			</h1>
-			<ul class="error-summary-list">
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        There was a problem
+      </h1>
+      <ul class="error-summary-list">
         <% @dataset.errors.each do |attr, message| %>
           <li>
             <a href="#id_<%= attr.to_s %>">
@@ -16,14 +16,14 @@
             </a>
             <span class="visuallyhidden">.</span>
           </li>
-				<% end %>
-			</ul>
-		</div>
+        <% end %>
+      </ul>
+    </div>
   <% end %>
 
   <h1 class="heading-large">Create a dataset</h1>
 
-  <%= form_for @dataset, url: datasets_path, method: :post do |f| %>
+  <%= form_for @dataset do |f| %>
 
     <%= dataset_field f, @dataset,
     input_type: :text_field,

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -17,8 +17,8 @@
     <% else %>
     <div id="confirm-delete-box">
       <h1 class="heading-medium error-summary-heading"><%= flash[:alert] %></h1>
-      <%= link_to "Yes, delete this dataset", @dataset, method: :delete, class: 'button confirm-delete-box__button' %>
-      <%= link_to "Cancel", edit_dataset_path(@dataset), class: 'secondary-button' %>
+      <%= link_to "Yes, delete this dataset", delete_dataset_path(@dataset.uuid, @dataset.name), method: :delete, class: 'button confirm-delete-box__button' %>
+      <%= link_to "Cancel", edit_dataset_path(@dataset.uuid, @dataset.name), class: 'secondary-button' %>
     </div>
     <% end %>
   </div>
@@ -43,21 +43,21 @@
       <th class="dgu-checklist__heading">Title</th>
       <td><%= @dataset.title %>
         <td class="dgu-checklist__actions">
-          <%= link_to 'Change', edit_dataset_path(@dataset) %>
+          <%= link_to 'Change', edit_dataset_path(@dataset.uuid, @dataset.name) %>
         </td>
     </tr>
     <tr>
       <th class="dgu-checklist__heading">Summary</th>
       <td><%= @dataset.summary %>
         <td class="dgu-checklist__actions">
-          <%= link_to 'Change', edit_dataset_path(@dataset) %>
+          <%= link_to 'Change', edit_dataset_path(@dataset.uuid, @dataset.name) %>
         </td>
     </tr>
     <tr>
       <th class="dgu-checklist__heading">Additional information</th>
       <td><%= @dataset.description %>
         <td class="dgu-checklist__actions">
-          <%= link_to 'Change', edit_dataset_path(@dataset) %>
+          <%= link_to 'Change', edit_dataset_path(@dataset.uuid, @dataset.name) %>
         </td>
     </tr>
     <tr>
@@ -72,9 +72,9 @@
       </td>
       <td class="dgu-checklist__actions">
         <% if @dataset.licence %>
-          <%= link_to 'Change', edit_dataset_licence_path(@dataset) %>
+          <%= link_to 'Change', edit_dataset_licence_path(@dataset.uuid, @dataset.name) %>
         <% else %>
-          <%= link_to 'Select', edit_dataset_licence_path(@dataset) %>
+          <%= link_to 'Select', edit_dataset_licence_path(@dataset.uuid, @dataset.name) %>
         <% end %>
       </td>
     </tr>
@@ -85,9 +85,9 @@
 
         <td class="dgu-checklist__actions">
           <% if @dataset.location1 %>
-            <%= link_to 'Change', edit_dataset_location_path(@dataset) %>
+            <%= link_to 'Change', edit_dataset_location_path(@dataset.uuid, @dataset.name) %>
           <% else %>
-            <%= link_to 'Add', edit_dataset_location_path(@dataset) %>
+            <%= link_to 'Add', edit_dataset_location_path(@dataset.uuid, @dataset.name) %>
           <% end %>
         </td>
     </tr>
@@ -96,9 +96,9 @@
       <td><%= friendly_frequency(@dataset.frequency) if @dataset.frequency %></td>
       <td class="dgu-checklist__actions">
         <% if @dataset.frequency %>
-          <%= link_to 'Change', edit_dataset_frequency_path(@dataset) %>
+          <%= link_to 'Change', edit_dataset_frequency_path(@dataset.uuid, @dataset.name) %>
         <% else %>
-          <%= link_to 'Select', edit_dataset_frequency_path(@dataset) %>
+          <%= link_to 'Select', edit_dataset_frequency_path(@dataset.uuid, @dataset.name) %>
         <% end %>
       </td>
     </tr>
@@ -116,9 +116,9 @@
       </td>
       <td class="dgu-checklist__actions">
         <% if @dataset.links.any? %>
-          <%= link_to 'Change', dataset_links_path(@dataset) %>
+          <%= link_to 'Change', dataset_links_path(@dataset.uuid, @dataset.name) %>
         <% else %>
-          <%= link_to 'Add', new_dataset_link_path(@dataset) %>
+          <%= link_to 'Add', new_dataset_link_path(@dataset.uuid, @dataset.name) %>
         <% end %>
       </td>
     </tr>
@@ -129,21 +129,21 @@
       <% end %>
       <td class="dgu-checklist__actions">
         <% if @dataset.docs.any? %>
-          <%= link_to 'Change', dataset_docs_path(@dataset) %>
+          <%= link_to 'Change', dataset_docs_path(@dataset.uuid, @dataset.name) %>
         <% else %>
-          <%= link_to 'Add', new_dataset_doc_path(@dataset) %>
+          <%= link_to 'Add', new_dataset_doc_path(@dataset.uuid, @dataset.name) %>
         <% end %>
       </td>
     </tr>
   </tbody>
 </table>
 
-<%= form_for @dataset, url: publish_dataset_path(@dataset), method: :post do |f| %>
+<%= form_for @dataset, url: publish_dataset_path(@dataset.uuid, @dataset.name), method: :post do |f| %>
   <p><%= f.submit @dataset.published? ? "Publish changes" : "Publish", class: 'button' %></p>
 <% end %>
 
 <% unless @dataset.published? %>
-  <p><%= link_to 'Delete this dataset', confirm_delete_dataset_path, class: 'secondary-button danger' %></p>
+  <p><%= link_to 'Delete this dataset', confirm_delete_dataset_path(@dataset.uuid, @dataset.name), class: 'secondary-button danger' %></p>
 <% end %>
 
 <p><%= link_to 'Back to manage your dataset', manage_path, class: 'secondary-button' %></p>

--- a/app/views/manage/_base.html.erb
+++ b/app/views/manage/_base.html.erb
@@ -35,8 +35,8 @@
           </td>
           <td class="dgu-datasets-table__actions">
             <% unless dataset.is_readonly? %>
-              <%= link_to 'Add Data', dataset_links_path(dataset) %>
-              <%= link_to 'Edit', dataset_path(dataset) %><br/>
+              <%= link_to 'Add Data', dataset_links_path(dataset.uuid, dataset.name) %>
+              <%= link_to 'Edit', edit_dataset_path(dataset.uuid, dataset.name) %><br/>
             <% end %>
           </td>
         </tr>

--- a/app/views/manage/_base.html.erb
+++ b/app/views/manage/_base.html.erb
@@ -36,7 +36,7 @@
           <td class="dgu-datasets-table__actions">
             <% unless dataset.is_readonly? %>
               <%= link_to 'Add Data', dataset_links_path(dataset.uuid, dataset.name) %>
-              <%= link_to 'Edit', edit_dataset_path(dataset.uuid, dataset.name) %><br/>
+              <%= link_to 'Edit', dataset_path(dataset.uuid, dataset.name) %><br/>
             <% end %>
           </td>
         </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,26 +13,58 @@ Rails.application.routes.draw do
 
   mount Sidekiq::Web => '/sidekiq' unless Rails.env.production?
 
-  resources :datasets do
-    member do
-      post 'publish',       to: 'datasets#publish'
-      get 'confirm_delete', to: 'datasets#confirm_delete'
-      get 'quality',        to: 'datasets#quality'
-    end
+  scope '/datasets' do
+    # links
+    get    ':uuid/*name/links/new',      to: 'datasets/links#new',          as: 'new_dataset_link'
+    get    ':uuid/*name/links/:id/edit', to: 'datasets/links#edit',         as: 'edit_dataset_link'
+    get    ':uuid/*name/links',          to: 'datasets/links#index',        as: 'dataset_links'
+    post   ':uuid/*name/links',          to: 'datasets/links#create'
+    put    ':uuid/*name/links/:id',      to: 'datasets/links#update',       as: 'update_dataset_link'
+    delete ':uuid/*name/links/:id',      to: 'datasets/links#destroy',      as: 'delete_dataset_link'
 
-    scope module: :datasets do
-      resource :licence
-      resource :location
-      resource :frequency
+    get    ':uuid/*name/links/:id/confirm_delete', to: 'datasets/links#confirm_delete', as: 'confirm_delete_dataset_link'
 
-      resources :links do
-        get 'confirm_delete', on: :member
-      end
+    # docs
+    get    ':uuid/*name/docs/new',      to: 'datasets/docs#new',        as: 'new_dataset_doc'
+    get    ':uuid/*name/docs/:id/edit', to: 'datasets/docs#edit',       as: 'edit_dataset_doc'
+    get    ':uuid/*name/docs',          to: 'datasets/docs#index',      as: 'dataset_docs'
+    post   ':uuid/*name/docs',          to: 'datasets/docs#create'
+    put    ':uuid/*name/docs/:id',      to: 'datasets/docs#update',     as: 'update_dataset_doc'
+    delete ':uuid/*name/docs/:id',      to: 'datasets/docs#destroy',    as: 'delete_dataset_doc'
 
-      resources :docs do
-        get 'confirm_delete', on: :member
-      end
-    end
+    get    ':uuid/*name/docs/:id/confirm_delete', to: 'datasets/docs#confirm_delete', as: 'confirm_delete_dataset_doc'
+
+    # licence
+    get    ':uuid/*name/licence/new',    to: 'datasets/licences#new',       as: 'new_dataset_licence'
+    get    ':uuid/*name/licence/edit',   to: 'datasets/licences#edit',      as: 'edit_dataset_licence'
+    post   ':uuid/*name/licences',       to: 'datasets/licences#create',    as: 'create_dataset_licence'
+    patch  ':uuid/*name/licence',        to: 'datasets/licences#update',    as: 'update_dataset_licence'
+
+    # location
+    get    ':uuid/*name/location/new',   to: 'datasets/locations#new',      as: 'new_dataset_location'
+    get    ':uuid/*name/location/edit',  to: 'datasets/locations#edit',      as: 'edit_dataset_location'
+    post   ':uuid/*name/locations',      to: 'datasets/locations#create',   as: 'create_dataset_location'
+    patch  ':uuid/*name/location',       to: 'datasets/locations#update',    as: 'update_dataset_location'
+
+    # frequency
+    get    ':uuid/*name/frequency/new',  to: 'datasets/frequencies#new',    as: 'new_dataset_frequency'
+    get    ':uuid/*name/frequency/edit', to: 'datasets/frequencies#edit',   as: 'edit_dataset_frequency'
+    post   ':uuid/*name/frequencies',    to: 'datasets/frequencies#create', as: 'create_dataset_frequency'
+    patch  ':uuid/*name/frequency',      to: 'datasets/frequencies#update', as: 'update_dataset_frequency'
+
+    # Datasets other
+    get    ':uuid/*name/confirm_delete', to: 'datasets#confirm_delete',     as: 'confirm_delete_dataset'
+    get    ':uuid/*name/quality',        to: 'datasets#quality',            as: 'dataset_quality'
+    post   ':uuid/*name/publish',        to: 'datasets#publish',            as: 'publish_dataset'
+
+    # Datasets CRUD
+    get    'new',                        to: 'datasets#new',                as: 'new_dataset'
+    get    ':uuid/*name/edit',           to: 'datasets#edit',               as: 'edit_dataset'
+    get    ':uuid/*name',                to: 'datasets#show',               as: 'dataset'
+    post   '/',                          to: 'datasets#create',             as: 'datasets'
+    patch  ':uuid/*name',                to: 'datasets#update',             as: 'update_dataset'
+    delete ':uuid/*name',                to: 'datasets#destroy',            as: 'delete_dataset'
+
   end
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     get    ':uuid/*name/links/:id/edit', to: 'datasets/links#edit',         as: 'edit_dataset_link'
     get    ':uuid/*name/links',          to: 'datasets/links#index',        as: 'dataset_links'
     post   ':uuid/*name/links',          to: 'datasets/links#create'
-    put    ':uuid/*name/links/:id',      to: 'datasets/links#update',       as: 'update_dataset_link'
+    patch  ':uuid/*name/links/:id',      to: 'datasets/links#update',       as: 'update_dataset_link'
     delete ':uuid/*name/links/:id',      to: 'datasets/links#destroy',      as: 'delete_dataset_link'
 
     get    ':uuid/*name/links/:id/confirm_delete', to: 'datasets/links#confirm_delete', as: 'confirm_delete_dataset_link'
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
     get    ':uuid/*name/docs/:id/edit', to: 'datasets/docs#edit',       as: 'edit_dataset_doc'
     get    ':uuid/*name/docs',          to: 'datasets/docs#index',      as: 'dataset_docs'
     post   ':uuid/*name/docs',          to: 'datasets/docs#create'
-    put    ':uuid/*name/docs/:id',      to: 'datasets/docs#update',     as: 'update_dataset_doc'
+    patch  ':uuid/*name/docs/:id',      to: 'datasets/docs#update',     as: 'update_dataset_doc'
     delete ':uuid/*name/docs/:id',      to: 'datasets/docs#destroy',    as: 'delete_dataset_doc'
 
     get    ':uuid/*name/docs/:id/confirm_delete', to: 'datasets/docs#confirm_delete', as: 'confirm_delete_dataset_doc'

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -15,7 +15,7 @@ describe DatasetsController, type: :controller do
                                  harvested: true,
                                  links: [FactoryGirl.create(:link)])
 
-    patch :update, params: { id: dataset.name, dataset: { title: "New title" } }
+    patch :update, params: { uuid: dataset.uuid, name: dataset.name, dataset: { title: "New title" } }
 
     dataset.valid?
 
@@ -28,7 +28,7 @@ describe DatasetsController, type: :controller do
 
     sign_in(user)
 
-    patch :update, params: { id: dataset.name, dataset: { title: "New title" } }
+    patch :update, params: { uuid: dataset.uuid, name: dataset.name, dataset: { title: "New title" } }
 
     dataset.reload
 
@@ -43,14 +43,15 @@ describe DatasetsController, type: :controller do
     user =  FactoryGirl.create(:user)
     organisation = FactoryGirl.create(:organisation, users: [user])
     dataset = FactoryGirl.create(:dataset,
+                                 name: "legit-name",
                                  organisation: organisation,
                                  links: [FactoryGirl.create(:link)])
 
     sign_in(user)
 
-    get :show, params: { id: dataset.id }
+    get :show, params: { uuid: dataset.uuid, name: "absolute-nonsense-name" }
 
-    expect(response).to redirect_to(dataset_url(dataset))
+    expect(response).to redirect_to(dataset_url(dataset.uuid, dataset.name))
   end
 
   it "returns '503 forbidden' error if a user is not allowed to view the requested dataset" do
@@ -69,7 +70,7 @@ describe DatasetsController, type: :controller do
 
     sign_in(user)
 
-    get :show, params: { id: forbidden_dataset.id }
+    get :show, params: { uuid: forbidden_dataset.uuid, name: forbidden_dataset.name }
 
     expect(response).to have_http_status(403)
   end
@@ -90,7 +91,7 @@ describe DatasetsController, type: :controller do
 
     sign_in(user)
 
-    get :edit, params: { id: forbidden_dataset.id }
+    get :edit, params: { uuid: forbidden_dataset.uuid, name: forbidden_dataset.name }
 
     expect(response).to have_http_status(403)
   end

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -109,7 +109,7 @@ describe "dataset creation" do
       # Ensure the dataset is indexed in Elastic
       client = Dataset.__elasticsearch__.client
       document = client.get({ index: Dataset.index_name, id: Dataset.last.id })
-      expect(document["_source"]["name"]).to eq("#{Dataset.last.uuid} #{Dataset.last.title}".parameterize)
+      expect(document["_source"]["name"]).to eq("#{Dataset.last.title}".parameterize)
     end
   end
 

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -138,7 +138,7 @@ describe "dataset creation" do
       click_link 'Manage datasets'
       expect(page).to have_content(dataset.title)
 
-      visit dataset_path(dataset)
+      visit dataset_path(dataset.uuid, dataset.name)
       expect(page).to have_content(dataset.title)
     end
   end
@@ -280,7 +280,7 @@ describe "dataset frequency options" do
     user
     sign_in_user
     dataset
-    visit new_dataset_frequency_path(dataset)
+    visit new_dataset_frequency_path(dataset.uuid, dataset.name)
   end
 
   context "when Never and Daily" do
@@ -506,7 +506,7 @@ describe "passing the frequency page" do
     user
     dataset
     sign_in_user
-    visit new_dataset_frequency_path(dataset)
+    visit new_dataset_frequency_path(dataset.uuid, dataset.name)
   end
 
   it "mandates entering a frequency" do

--- a/spec/features/edit_dataset_spec.rb
+++ b/spec/features/edit_dataset_spec.rb
@@ -11,7 +11,6 @@ describe 'editing datasets' do
     user
     sign_in_user
     build_datasets
-    click_link 'Manage datasets'
   end
 
   it "should be able to go to datasets's page" do
@@ -22,10 +21,8 @@ describe 'editing datasets' do
 
   context 'editing published datasets from show page' do
     before(:each) do
-      # url = "https://test.data.gov.uk/api/3/action/package_patch"
-      # stub_request(:any, url).to_return(status: 200)
       click_link 'Manage datasets'
-      find(:xpath, "//a[@href='#{dataset_path(published_dataset)}']").click
+      find(:xpath, "//a[@href='#{dataset_path(published_dataset.uuid, published_dataset.name)}']").click
     end
 
     it "should be able to update title" do
@@ -165,21 +162,21 @@ describe 'editing datasets' do
     end
 
     it "should be able to publish a published dataset" do
-      visit dataset_url(published_dataset)
+      visit dataset_url(published_dataset.uuid, published_dataset.name)
       expect(page).to have_selector("input[type=submit][value='Publish changes']")
     end
 
     it "should not be possible to delete a published dataset" do
-      visit dataset_url(published_dataset)
+      visit dataset_url(published_dataset.uuid, published_dataset.name)
       expect(page).to_not have_selector(:css, 'a[href="/datasets/test-title-published/confirm_delete"]')
       expect(page).to_not have_content('Delete this dataset')
 
-      visit confirm_delete_dataset_path(published_dataset)
+      visit confirm_delete_dataset_path(published_dataset.uuid, published_dataset.name)
       expect(page).to have_content "Published datasets cannot be deleted"
     end
 
     it "should be able to publish an complete dataset" do
-      visit dataset_url(unpublished_dataset)
+      visit dataset_url(unpublished_dataset.uuid, unpublished_dataset.name)
       expect(unpublished_dataset.published?).to be false
 
       click_button 'Publish'
@@ -189,23 +186,20 @@ describe 'editing datasets' do
     end
 
     it "should not be possible to publish an incomplete dataset" do
-      visit dataset_url(unfinished_dataset)
+      visit dataset_url(unfinished_dataset.uuid, unfinished_dataset.name)
       expect(unfinished_dataset.published?).to be false
       click_button 'Publish'
       expect(page).to have_content 'There was a problem'
       expect(page).not_to have_content 'Your dataset has been published'
-      expect(current_path).to eq publish_dataset_path(unfinished_dataset)
+      expect(current_path).to eq publish_dataset_path(unfinished_dataset.uuid, unfinished_dataset.name)
     end
   end
 
   context "editing draft datasets from the show page" do
     it "is possible to delete a draft dataset" do
-      # url = "https://test.data.gov.uk/api/3/action/package_patch"
-      # stub_request(:any, url).to_return(status: 200)
-
-      visit dataset_url(unpublished_dataset)
+      visit dataset_url(unpublished_dataset.uuid, unpublished_dataset.name)
       click_link 'Delete this dataset'
-      expect(current_path).to eq confirm_delete_dataset_path(unpublished_dataset)
+      expect(current_path).to eq confirm_delete_dataset_path(unpublished_dataset.uuid, unpublished_dataset.name)
       click_link "Yes, delete this dataset"
       expect(current_path).to eq '/manage'
       expect(page).to have_content "The dataset '#{unpublished_dataset.title}' has been deleted"

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -1,20 +1,7 @@
 require 'rails_helper'
 
 describe Dataset do
-
   let! (:org)  { @org = Organisation.create!(name: "land-registry", title: "Land Registry") }
-
-  it "can create a new dataset" do
-    d = Dataset.new(
-      title: "This is a dataset",
-      summary: "Summary",
-      frequency: "daily",
-      organisation_id: @org.id
-    )
-
-    expect(d.save).to eq(true)
-    expect(d.name).to eq("#{d.uuid} #{d.title}".parameterize)
-  end
 
   it "requires a valid title" do
     d = Dataset.new
@@ -35,19 +22,20 @@ describe Dataset do
     dataset = FactoryGirl.create(:dataset,
                                  title: "My awesome dataset")
 
-    expect(dataset.name).to eq("#{dataset.uuid} #{dataset.title}".parameterize)
+    expect(dataset.name).to eq("#{dataset.title}".parameterize)
   end
 
   it "generates a new slug when the title has changed" do
     url = "https://test.data.gov.uk/api/3/action/package_patch"
     stub_request(:any, url).to_return(status: 200)
+
     dataset = FactoryGirl.create(:dataset,
                                  uuid: 1234,
                                  title: "My awesome dataset")
 
     dataset.update(title: "My Even Better Dataset")
 
-    expect(dataset.name).to eq("1234-my-even-better-dataset")
+    expect(dataset.name).to eq("my-even-better-dataset")
   end
 
   it "validates more strictly when publishing" do


### PR DESCRIPTION
This PR introduces:

* new URLs for datasets. The URL structure is now: `/datasets/:uuid/:name`, where name acts as the datasets URL slug,

* generates a new slug every time a dataset's title changes,

* redirects of any dataset URL with an old slug to the URL with the latest up to date slug. The slug is now entirely cosmetic. As long as the `:uuid` is correct in `/datasets/:uuid/:name`, the user will be directed to the correct dataset.

trello: https://trello.com/c/bTQ1Nspf/48-in-publish-beta-redirect-dataset-urls-with-old-slugs-to-the-latest-version-the-url-in-order-to-avoid-broken-links-when-a-dataset