### PR TITLE
Remove dataset weekly frequency + add dates to daily datafiles

### DIFF
--- a/app/controllers/datasets/links_controller.rb
+++ b/app/controllers/datasets/links_controller.rb
@@ -60,8 +60,7 @@ class Datasets::LinksController < ApplicationController
     params.require(:link).permit(
       :url,
       :name,
-      :start_day, :start_month, :start_year,
-      :end_day, :end_month, :end_year,
+      :day, :month, :year,
       :year,
       :quarter
     )

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -30,7 +30,7 @@ class Dataset < ApplicationRecord
   has_many :docs
   has_one :inspire_dataset
 
-  validates :frequency, inclusion: { in: %w(daily weekly monthly quarterly annually financial-year never) },
+  validates :frequency, inclusion: { in: %w(daily monthly quarterly annually financial-year never) },
                         allow_nil: true # To allow creation before setting this value
   validates :title, presence: true, format: { with: TITLE_FORMAT }
   validates :summary, presence: true
@@ -134,10 +134,6 @@ class Dataset < ApplicationRecord
     frequency == 'daily'
   end
 
-  def weekly?
-    frequency == 'weekly'
-  end
-
   def monthly?
     frequency == 'monthly'
   end
@@ -156,10 +152,6 @@ class Dataset < ApplicationRecord
 
   def never?
     frequency == 'never'
-  end
-
-  def one_off?
-    never?
   end
 
   def initialised?

--- a/app/models/legacy/dataset.rb
+++ b/app/models/legacy/dataset.rb
@@ -46,7 +46,7 @@ class Legacy::Dataset < SimpleDelegator
   end
 
   def custom_frequency
-    return frequency if ['daily', 'weekly', 'one-off'].include?(frequency)
+    return frequency if ['daily', 'one-off'].include?(frequency)
   end
 
   FREQUENCY_MAP =
@@ -54,7 +54,6 @@ class Legacy::Dataset < SimpleDelegator
       'quarterly' => 'quarterly',
       'monthly' => 'monthly',
       'daily' => 'other',
-      'weekly' => 'other',
       'never' => 'never',
       'discontinued' => 'discontinued',
       'one-off' => 'other'

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -3,7 +3,7 @@ class Link < Datafile
 
   before_save :set_date
 
-  validate :validate_date_input, unless: ->{ dataset.never? }
+  validate  :validate_date_input, unless: ->{ dataset.never? }
   validates :quarter, presence: true, if: ->{ dataset.quarterly? }
 
   def dates
@@ -61,13 +61,13 @@ class Link < Datafile
 
   def validate_date_input
     validate_date  if dataset.daily?
-    validate_month if dataset.monthly?
+    validate_month if dataset.daily? || dataset.monthly?
     validate_year
   end
 
   def validate_date
     if (daily_date rescue ArgumentError) == ArgumentError
-      errors.add(:date, "Please enter a valid date".squish)
+      errors.add(:date, 'Please enter a valid date')
     end
   end
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,87 +1,49 @@
 class Link < Datafile
-  attr_accessor :start_day, :start_month, :start_year,
-                :end_day,   :end_month,   :end_year
+  attr_accessor :day, :month, :year
 
-  before_save :set_dates
+  before_save :set_date
 
-  validate  :dates_valid, unless: ->{ documentation? }
-  validates :quarter, presence: true, if: ->{ !documentation && dataset.quarterly? }
+  validate :validate_date_input, unless: ->{ dataset.never? }
+  validates :quarter, presence: true, if: ->{ dataset.quarterly? }
 
   def dates
     {
-      start: {
-        day:   start_day.presence   || start_date&.day,
-        month: start_month.presence || start_date&.month,
-        year:  start_year.presence  || start_date&.year
-      },
-      end: {
-        day:   end_day   || end_date&.day,
-        month: end_month || end_date&.month,
-        year:  end_year  || end_date&.year
-      }
+      day:   day   || end_date&.day,
+      month: month || end_date&.month,
+      year:  year  || end_date&.year
     }.with_indifferent_access
   end
 
-  def set_dates
-    self.start_date, self.end_date = start_and_end_dates
+  def set_date
+    self.end_date = compute_date
   end
 
   private
 
-  def start_and_end_dates
-    return weekly_dates           if dataset.weekly?
-    return monthly_dates          if dataset.monthly?
-    return quarterly_dates        if dataset.quarterly?
-    return yearly_dates           if dataset.annually?
-    return financial_yearly_dates if dataset.financial_yearly?
+  def compute_date
+    return daily_date            if dataset.daily?
+    return monthly_date          if dataset.monthly?
+    return quarterly_date        if dataset.quarterly?
+    return yearly_date           if dataset.annually?
+    return financial_yearly_date if dataset.financial_yearly?
   end
 
-  def weekly_dates
-    [date_start, date_end]
+  def daily_date
+    Date.new(year.to_i,
+             month.to_i,
+             day.to_i)
   end
 
-  def monthly_dates
-    [
-      date_start,
-      date_start.end_of_month
-    ]
+  def monthly_date
+    Date.new(year.to_i, month.to_i).end_of_month
   end
 
-  def quarterly_dates
-    [
-      quarter_to_date,
-      (quarter_to_date + 2.months).end_of_month
-    ]
-  end
-
-  def yearly_dates
-    [
-      Date.new(start_year.to_i),
-      Date.new(start_year.to_i, 12).end_of_month
-    ]
-  end
-
-  def financial_yearly_dates
-    [
-      Date.new(start_year.to_i, 4, 1),
-      Date.new(start_year.to_i + 1, 3).end_of_month
-    ]
-  end
-
-  def date_start
-    Date.new(start_year.to_i,
-             start_month.to_i,
-             start_day.to_i)
-  end
-
-  def date_end
-    Date.new(end_year.to_i,
-             end_month.to_i,
-             end_day.to_i)
+  def quarterly_date
+    (quarter_to_date + 2.months).end_of_month
   end
 
   def quarter_to_date
-    year_start = Date.new(start_year.to_i).beginning_of_year
+    year_start = Date.new(year.to_i).beginning_of_year
     year_start + (quarter_offset - 1).months
   end
 
@@ -89,63 +51,35 @@ class Link < Datafile
     4 + (quarter.to_i - 1) * 3 # Q1: 4, Q2: 7, Q3: 10, Q4: 13
   end
 
-  def dates_valid
-    validate_days
-    validate_months
-    validate_years
-    validate_start_date if dataset.monthly? || dataset.weekly?
-    validate_end_date   if dataset.weekly?
+  def yearly_date
+    Date.new(year.to_i).end_of_year
   end
 
-  def validate_days
-    days.compact.each do |attr, day|
-      if day.to_i < 1 || day.to_i > 31
-        errors.add(attr, "Please enter a valid #{attr.to_s.humanize.downcase}")
-      end
+  def financial_yearly_date
+    Date.new(year.to_i + 1).end_of_quarter
+  end
+
+  def validate_date_input
+    validate_date  if dataset.daily?
+    validate_month if dataset.monthly?
+    validate_year
+  end
+
+  def validate_date
+    if (daily_date rescue ArgumentError) == ArgumentError
+      errors.add(:date, "Please enter a valid date".squish)
     end
   end
 
-  def validate_months
-    months.compact.each do |attr, month_number|
-      if month_number.to_i < 1 || month_number.to_i > 12
-        attr = "month" if dataset.monthly?
-        errors.add(attr, "Please enter a valid #{attr.to_s.humanize.downcase}")
-      end
+  def validate_month
+    if month.to_i < 1 || month.to_i > 12
+      errors.add(:month, 'Please enter a valid month')
     end
   end
 
-  def validate_years
-    years.compact.each do |attr, year|
-      if year.to_i < 1000 || year.to_i > 5000
-        attr = "year" unless dataset.weekly?
-        errors.add(attr, "Please enter a valid #{attr.to_s.humanize.downcase}")
-      end
+  def validate_year
+    if year.to_i < 1000 || year.to_i > 5000
+      errors.add(:year, 'Please enter a valid year')
     end
-  end
-
-  def validate_start_date
-    if (date_start rescue ArgumentError) == ArgumentError
-      period = "start" if dataset.weekly?
-      errors.add(:start_date, "Please enter a valid #{period} date".squish)
-    end
-  end
-
-  def validate_end_date
-    if (date_end rescue ArgumentError) == ArgumentError
-      period = "end" if dataset.weekly?
-      errors.add(:end_date, "Please enter a valid #{period} date".squish)
-    end
-  end
-
-  def days
-    { start_day: start_day, end_day: end_day }.compact
-  end
-
-  def months
-    { start_month: start_month, end_month: end_month }.compact
-  end
-
-  def years
-    { start_year: start_year, end_year: end_year }.compact
   end
 end

--- a/app/views/datasets/frequencies/edit.html.erb
+++ b/app/views/datasets/frequencies/edit.html.erb
@@ -4,11 +4,11 @@
 
 <div class="datasets">
   <% if @dataset.errors.any? %>
-		<div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-			<h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-				There was a problem
-			</h1>
-			<ul class="error-summary-list">
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        There was a problem
+      </h1>
+      <ul class="error-summary-list">
         <% @dataset.errors.each do |attr, message| %>
           <li>
             <a href="#<%= attr.to_s %>_form_group">
@@ -16,9 +16,9 @@
             </a>
             <span class="visuallyhidden">.</span>
           </li>
-				<% end %>
-			</ul>
-		</div>
+        <% end %>
+      </ul>
+    </div>
   <% end %>
   <h1 class="heading-large">How frequently is this dataset updated?</h1>
 
@@ -31,11 +31,6 @@
         input_type: :radio_button,
         label: 'Daily',
         value: 'daily' %>
-        <%= dataset_field f, @dataset,
-        name: 'frequency',
-        input_type: :radio_button,
-        label: 'Weekly',
-        value: 'weekly' %>
         <%= dataset_field f, @dataset,
         name: 'frequency',
         input_type: :radio_button,

--- a/app/views/datasets/frequencies/new.html.erb
+++ b/app/views/datasets/frequencies/new.html.erb
@@ -43,11 +43,6 @@
         <%= dataset_field f, @dataset,
         name: 'frequency',
         input_type: :radio_button,
-        label: 'Weekly',
-        value: 'weekly' %>
-        <%= dataset_field f, @dataset,
-        name: 'frequency',
-        input_type: :radio_button,
         label: 'Monthly',
         value: 'monthly' %>
         <%= dataset_field f, @dataset,

--- a/app/views/datasets/links/_date_field.html.erb
+++ b/app/views/datasets/links/_date_field.html.erb
@@ -1,40 +1,45 @@
-<div class="form-group" id="<%= period %>_date_form_group">
+<div class="form-group" id="date_form_group">
   <fieldset>
     <legend>
       <span class="form-label-bold">
-          <%= period.humanize %> Date
+          Date
         <span class="form-hint">For example, 31 3 2016</span>
       </span>
     </legend>
 
-    <div class="form-group form-date<% if @link.errors.key? (period+"_date").to_sym %> form-group-error<% end %>">
-      <% if @link.errors.key? (period+"_date").to_sym %>
-        <span class="error-message">Please enter a valid <%= period %> date</span>
+    <div class="form-group form-date <% "form-group-error" if @link.errors.any? %>">
+      <% @link.errors[:date].each do |message| %>
+        <span class="error-message"><%= message %></span>
       <% end %>
-      <div class="form-group form-group-day<% if @link.errors.key? (period+"_day").to_sym %> form-group-error<% end %>">
-        <label for="#<%= period %>_day">
-          <span class="form-label">Day</span>
-          <% if @link.errors.key? (period+"_day").to_sym %>
-            <span class="error-message">Please enter a valid <%= period %> day</span>
-          <% end %>
-        </label>
-        <%= text_field_tag "link[#{period}_day]", @link.dates[period][:day], id: "#{period}_day", class: "form-control" %>
+
+      <div class="form-group form-group-day<%= "form-group-error" if @link.errors[:day].any? %>">
+        <label for="day">Day</label>
+
+        <% @link.errors[:day].each do |message| %>
+          <span class="error-message"><%= message %></span>
+        <% end %>
+
+        <%= text_field_tag "link[day]", @link.dates[:day], id: "day", class: "form-control" %>
       </div>
 
-      <div class="form-group form-group-month<% if @link.errors.key? (period+"_day").to_sym %> form-group-error<% end %>">
-        <label for="<%= period %>_month">Month</label>
-        <% if @link.errors.key? (period+"_month").to_sym %>
-          <span class="error-message">Please enter a valid <%= period %> month</span>
+      <div class="form-group form-group-month<%= "form-group-error" if @link.errors[:month].any? %>">
+        <label for="month">Month</label>
+
+        <% @link.errors[:month].each do |message| %>
+          <span class="error-message"><%= message %></span>
         <% end %>
-        <%= text_field_tag "link[#{period}_month]", @link.dates[period][:month], id: "#{period}_month", class: "form-control" %>
+
+        <%= text_field_tag "link[month]", @link.dates[:month], id: "month", class: "form-control" %>
       </div>
 
-      <div class="form-group form-group-year<% if @link.errors.key? (period+"_day").to_sym %> form-group-error<% end %>">
-        <label for="<%= period %>_year">year</label>
-        <% if @link.errors.key? (period+"_year").to_sym %>
-          <span class="error-message">Please enter a valid <%= period %> year</span>
+      <div class="form-group form-group-year<%= "form-group-error" if @link.errors[:year].any? %>">
+        <label for="year">Year</label>
+
+        <% @link.errors[:year].each do |message| %>
+          <span class="error-message"><%= message %></span>
         <% end %>
-        <%= text_field_tag "link[#{period}_year]", @link.dates[period][:year], id: "#{period}_year", class: "form-control" %>
+
+        <%= text_field_tag "link[year]", @link.dates[:year], id: "year", class: "form-control" %>
       </div>
     </div>
   </fieldset>

--- a/app/views/datasets/links/_month_input.html.erb
+++ b/app/views/datasets/links/_month_input.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group" id="start_date_form_group">
+<div class="form-group" id="date_form_group">
   <fieldset>
     <legend>
       <span class="form-label-bold">
@@ -8,32 +8,22 @@
     </legend>
 
     <div class="form-date">
-      <div class="form-group form-group-month<% if @link.errors[:start_month].present? %> form-group-error<% end %>">
-        <%= hidden_field_tag "link[start_day]", 1 %>
-
-        <label for="start_month">Month</label>
+      <div class="form-group form-group-month<% if @link.errors[:month].present? %> form-group-error<% end %>">
+        <label for="month">Month</label>
         <% @link.errors[:month].each do |message| %>
           <span class="error-message"><%= message %></span>
         <% end %>
 
-        <% @link.errors[:start_month].each do |message| %>
-          <span class="error-message"><%= message %></span>
-        <% end %>
-
-        <%= text_field_tag "link[start_month]", @link.dates[:start][:month], id: "start_month", class: "form-control" %>
+        <%= text_field_tag "link[month]", @link.dates[:month], id: "month", class: "form-control" %>
       </div>
 
-      <div class="form-group form-group-year<% if @link.errors[:start_year].present? %> form-group-error<% end %>">
-        <label for="start_year">Year</label>
+      <div class="form-group form-group-year<% if @link.errors[:year].present? %> form-group-error<% end %>">
+        <label for="year">Year</label>
         <% @link.errors[:year].each do |message| %>
           <span class="error-message"><%= message %></span>
         <% end %>
 
-        <% @link.errors[:start_year].each do |message| %>
-          <span class="error-message"><%= message %></span>
-        <% end %>
-
-        <%= text_field_tag "link[start_year]", @link.dates[:start][:year], id: "start_year", class: "form-control" %>
+        <%= text_field_tag "link[year]", @link.dates[:year], id: "year", class: "form-control" %>
       </div>
     </div>
   </fieldset>

--- a/app/views/datasets/links/_quarter_inputs.html.erb
+++ b/app/views/datasets/links/_quarter_inputs.html.erb
@@ -31,7 +31,7 @@
   </fieldset>
 </div>
 
-<div class="form-group<% if @link.errors[:start_year].present? %> form-group-error<% end %>">
+<div class="form-group<% if @link.errors[:year].present? %> form-group-error<% end %>">
   <fieldset>
     <legend class="visuallyhidden">Year</legend>
     <div class="form-date">
@@ -40,11 +40,7 @@
         <% @link.errors[:year].each do |message| %>
           <span class="error-message"><%= message %></span>
         <% end %>
-
-        <% @link.errors[:start_year].each do |message| %>
-          <span class="error-message"><%= message %></span>
-        <% end %>
-        <%= text_field_tag 'link[start_year]', @link.dates[:start][:year], id: "period_year", class: "form-control" %>
+        <%= text_field_tag 'link[year]', @link.dates[:year], id: "period_year", class: "form-control" %>
       </div>
     </div>
   </fieldset>

--- a/app/views/datasets/links/_year_input.html.erb
+++ b/app/views/datasets/links/_year_input.html.erb
@@ -4,16 +4,13 @@
       <span class="form-label-bold">Time period for this link</span>
     </legend>
     <div class="form-date">
-      <div id="year_form_group" class="form-group form-group-year<% if @link.errors[:start_year].present? %> form-group-error<% end %>">
+      <div id="year_form_group" class="form-group form-group-year<% if @link.errors[:year].present? %> form-group-error<% end %>">
         <label class="form-label" for="period_year">Year</label>
         <span class="form-hint">For example, 2016</span>
-        <% @link.errors[:start_year].each do |message| %>
-          <span class="error-message"><%= message %></span>
-        <% end %>
         <% @link.errors[:year].each do |message| %>
           <span class="error-message"><%= message %></span>
         <% end %>
-        <%= text_field_tag 'link[start_year]', @link.dates[:start][:year], id: "period_year", class: "form-control" %>
+        <%= text_field_tag 'link[year]', @link.dates[:year], id: "period_year", class: "form-control" %>
       </div>
     </div>
   </fieldset>

--- a/app/views/datasets/links/edit.html.erb
+++ b/app/views/datasets/links/edit.html.erb
@@ -41,6 +41,10 @@
     hint: 'The link name mustn’t be the same as the URL. It should clearly describe the data so users can find it easily.',
     value: @link.name %>
 
+    <% if @dataset.daily? %>
+      <%= render 'date_field' %>
+    <% end %>
+
     <% if @dataset.monthly? %>
       <%= render 'month_input' %>
     <% end %>

--- a/app/views/datasets/links/edit.html.erb
+++ b/app/views/datasets/links/edit.html.erb
@@ -41,11 +41,6 @@
     hint: 'The link name mustn’t be the same as the URL. It should clearly describe the data so users can find it easily.',
     value: @link.name %>
 
-    <% if @dataset.weekly? %>
-      <%= render 'date_field', period: 'start' %>
-      <%= render 'date_field', period: 'end' %>
-    <% end %>
-
     <% if @dataset.monthly? %>
       <%= render 'month_input' %>
     <% end %>

--- a/app/views/datasets/links/new.html.erb
+++ b/app/views/datasets/links/new.html.erb
@@ -41,6 +41,10 @@
     hint: 'The link name mustn’t be the same as the URL. It should clearly describe the data so users can find it easily.',
     value: @link.name %>
 
+    <% if @dataset.daily? %>
+      <%= render 'date_field' %>
+    <% end %>
+
     <% if @dataset.monthly? %>
       <%= render 'month_input' %>
     <% end %>

--- a/app/views/datasets/links/new.html.erb
+++ b/app/views/datasets/links/new.html.erb
@@ -41,11 +41,6 @@
     hint: 'The link name mustn’t be the same as the URL. It should clearly describe the data so users can find it easily.',
     value: @link.name %>
 
-    <% if @dataset.weekly? %>
-      <%= render 'date_field', period: 'start' %>
-      <%= render 'date_field', period: 'end' %>
-    <% end %>
-
     <% if @dataset.monthly? %>
       <%= render 'month_input' %>
     <% end %>

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -30,7 +30,7 @@ describe "dataset creation" do
       fill_in "dataset[description]", with: "my test dataset description"
       click_button "Save and continue"
 
-      expect(Dataset.where(title: "my test dataset").length).to eq(1)
+      expect(Dataset.where(title: "my test dataset").size).to eq(1)
       expect(Dataset.last.stage).to eq("initialised")
 
       # PAGE 2: Licence
@@ -60,7 +60,7 @@ describe "dataset creation" do
       fill_in 'link[name]', with: 'my test datafile'
       click_button "Save and continue"
 
-      expect(Dataset.last.links.length).to eq(1)
+      expect(Dataset.last.links.size).to eq(1)
       expect(Dataset.last.links.last.url).to eq('https://localhost')
       expect(Dataset.last.links.last.name).to eq('my test datafile')
 
@@ -74,7 +74,7 @@ describe "dataset creation" do
       fill_in 'doc[name]', with: 'my test doc'
       click_button "Save and continue"
 
-      expect(Dataset.last.docs.length).to eq(1)
+      expect(Dataset.last.docs.size).to eq(1)
       expect(Dataset.last.docs.last.url).to eq('https://localhost/doc')
       expect(Dataset.last.docs.last.name).to eq('my test doc')
       expect(Dataset.last.stage).to eq("initialised")
@@ -127,7 +127,7 @@ describe "dataset creation" do
       fill_in "dataset[description]", with: "my test dataset description"
       click_button "Save and continue"
 
-      expect(Dataset.where(title: "my test dataset").length).to eq(1)
+      expect(Dataset.where(title: "my test dataset").size).to eq(1)
       expect(Dataset.find_by(title: "my test dataset").creator_id).to eq(user.id)
     end
 
@@ -161,7 +161,7 @@ describe "starting a new draft with invalid inputs" do
     expect(page).to have_content("There was a problem")
     expect(page).to have_content("Please enter a valid title", count: 2)
     expect(page).to have_selector("div", :class => "form-group-error")
-    expect(Dataset.where(title: "my test dataset").length).to eq(0)
+    expect(Dataset.where(title: "my test dataset").size).to eq(0)
     # recover
     fill_in "dataset[title]", with: "my test dataset"
     fill_in "dataset[summary]", with: "my test dataset summary"
@@ -176,7 +176,7 @@ describe "starting a new draft with invalid inputs" do
     expect(page).to have_content("There was a problem")
     expect(page).to have_content("Please provide a summary", count: 2)
     expect(page).to have_selector("div", :class => "form-group-error")
-    expect(Dataset.where(title: "my test dataset").length).to eq(0)
+    expect(Dataset.where(title: "my test dataset").size).to eq(0)
     # recover
     fill_in "dataset[title]", with: "my test dataset"
     fill_in "dataset[summary]", with: "my test dataset summary"
@@ -190,7 +190,7 @@ describe "starting a new draft with invalid inputs" do
     expect(page).to have_content("There was a problem")
     expect(page).to have_content("Please enter a valid title", count: 2)
     expect(page).to have_content("Please provide a summary", count: 2)
-    expect(Dataset.where(title: "my test dataset").length).to eq(0)
+    expect(Dataset.where(title: "my test dataset").size).to eq(0)
     # recover
     fill_in "dataset[title]", with: "my test dataset"
     fill_in "dataset[summary]", with: "my test dataset summary"
@@ -287,15 +287,12 @@ describe "dataset frequency options" do
       choose option: 'never'
       click_button "Save and continue"
 
-      expect(page).to_not have_content('Start Date')
-      expect(page).to_not have_content('End Date')
       expect(page).to_not have_content('Year')
 
       fill_in 'link[url]', with: 'https://localhost/doc'
       fill_in 'link[name]', with: 'my test doc'
       click_button "Save and continue"
 
-      expect(Dataset.last.datafiles.last.start_date).to be_nil
       expect(Dataset.last.datafiles.last.end_date).to be_nil
     end
 
@@ -303,80 +300,11 @@ describe "dataset frequency options" do
       choose option: 'daily'
       click_button "Save and continue"
 
-      expect(page).to_not have_content('Start Date')
-      expect(page).to_not have_content('End Date')
-      expect(page).to_not have_content('Year')
-
       fill_in 'link[url]', with: 'https://localhost/doc'
       fill_in 'link[name]', with: 'my test doc'
       click_button "Save and continue"
 
-      expect(Dataset.last.datafiles.last.start_date).to be_nil
       expect(Dataset.last.datafiles.last.end_date).to be_nil
-    end
-  end
-
-  context "when WEEKLY" do
-    before(:each) do
-      url = "https://test.data.gov.uk/api/3/action/package_patch"
-      stub_request(:any, url).to_return(status: 200)
-      choose option: 'weekly'
-      click_button "Save and continue"
-      fill_in 'link[url]', with: 'https://localhost/doc'
-      fill_in 'link[name]', with: 'my test doc'
-    end
-
-    it "shows start and end date fields and sets dates" do
-      expect(page).to     have_content('Start Date')
-      expect(page).to     have_content('End Date')
-
-      # Start Date
-      fill_in 'link[start_day]',   with: '1'
-      fill_in 'link[start_month]', with: '1'
-      fill_in 'link[start_year]',  with: '2020'
-
-      # End Date
-      fill_in 'link[end_day]',   with: '8'
-      fill_in 'link[end_month]', with: '1'
-      fill_in 'link[end_year]',  with: '2020'
-
-      click_button "Save and continue"
-
-      expect(Dataset.last.datafiles.last.start_date).to eq(Date.new(2020, 1, 1))
-      expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(2020, 1, 8))
-    end
-
-    it "displays errors when dates aren't entered" do
-
-      click_button "Save and continue"
-
-      expect(page).to have_content("There was a problem")
-      expect(page).to have_content("Please enter a valid start day")
-      expect(page).to have_content("Please enter a valid start month")
-      expect(page).to have_content("Please enter a valid start year")
-      expect(page).to have_content("Please enter a valid end day")
-      expect(page).to have_content("Please enter a valid end month")
-      expect(page).to have_content("Please enter a valid end year")
-    end
-
-    it "displays errors when dates aren't valid" do
-
-      fill_in 'link[start_day]', with: '30'
-      fill_in 'link[start_month]', with: '02'
-      fill_in 'link[start_year]',  with: '2020'
-
-      fill_in 'link[end_day]', with: '30'
-      fill_in 'link[end_month]', with: '03'
-      fill_in 'link[end_year]',  with: '2020'
-
-
-      click_button "Save and continue"
-
-      expect(page).to have_content("There was a problem")
-      expect(page).to_not have_content("Please enter a valid day")
-      expect(page).to_not have_content("Please enter a valid month")
-      expect(page).to_not have_content("Please enter a valid year")
-      expect(page).to have_content("Please enter a valid start date")
     end
   end
 
@@ -390,24 +318,19 @@ describe "dataset frequency options" do
       fill_in 'link[name]', with: 'my test doc'
     end
 
-    it "shows start date field and sets dates" do
-      expect(page).to_not have_content('Start Date')
-      expect(page).to_not have_content('End Date')
+    it "shows date fields and sets end date" do
       expect(page).to     have_content('Month')
       expect(page).to     have_content('Year')
 
-      # Start Date
-      fill_in 'link[start_month]', with: '1'
-      fill_in 'link[start_year]',  with: '2020'
+      fill_in 'link[month]', with: '1'
+      fill_in 'link[year]',  with: '2020'
 
       click_button "Save and continue"
 
-      expect(Dataset.last.datafiles.last.start_date).to eq(Date.new(2020, 1, 1))
       expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(2020, 1).end_of_month)
     end
 
     it "displays errors when dates aren't entered" do
-
       click_button "Save and continue"
 
       expect(page).to have_content("There was a problem")
@@ -425,68 +348,55 @@ describe "dataset frequency options" do
     end
 
     def pick_quarter(quarter)
-      expect(page).to_not have_content('Start Date')
-      expect(page).to_not have_content('End Date')
-      expect(page).to_not have_content('Month')
       expect(page).to     have_content('Year')
       expect(page).to     have_content('Quarter')
       fill_in 'link[url]', with: 'https://localhost/doc'
       fill_in 'link[name]', with: 'my test doc'
       choose option: quarter.to_s
-      fill_in "link[start_year]", with: Date.today.year
+      fill_in "link[year]", with: Date.today.year
       click_button "Save and continue"
     end
 
     it "calculates correct dates for Q1" do
       pick_quarter(1)
-      expect(Dataset.last.datafiles.last.start_date).to eq(Date.new(Date.today.year, 4, 1))
       expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(Date.today.year, 6).end_of_month)
     end
 
     it "calculates correct dates for Q2" do
       pick_quarter(2)
-      expect(Dataset.last.datafiles.last.start_date).to eq(Date.new(Date.today.year, 7, 1))
       expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(Date.today.year, 9).end_of_month)
     end
 
     it "calculates correct dates for Q3" do
       pick_quarter(3)
-      expect(Dataset.last.datafiles.last.start_date).to eq(Date.new(Date.today.year, 10, 1))
       expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(Date.today.year, 12).end_of_month)
     end
 
     it "calculates correct dates for Q4" do
       pick_quarter(4)
-      expect(Dataset.last.datafiles.last.start_date).to eq(Date.new(Date.today.year, 1, 1) + 1.year)
       expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(Date.today.year, 3).end_of_month + 1.year)
     end
   end
 
-  context "when YEARLY" do
-
+  context "when ANNUALLY" do
     def pick_year(year_type)
       choose option: year_type
       click_button "Save and continue"
-      expect(page).to_not have_content('Start Date')
-      expect(page).to_not have_content('End Date')
-      expect(page).to_not have_content('Month')
       expect(page).to     have_content('Year')
       fill_in 'link[url]', with: 'https://localhost/doc'
       fill_in 'link[name]', with: 'my test doc'
-      fill_in 'link[start_year]',  with: '2015'
+      fill_in 'link[year]',  with: '2015'
       click_button "Save and continue"
     end
 
-    it "shows year field and sets dates" do
+    it "shows year field and sets end date" do
       pick_year('annually')
-      expect(Dataset.last.datafiles.last.start_date).to eq(Date.new(2015, 1, 1))
-      expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(2015, 12).end_of_month)
+      expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(2015).end_of_year)
     end
 
-    it "shows financial year and sets dates" do
+    it "shows financial year and sets end date" do
       pick_year('financial-year')
-      expect(Dataset.last.datafiles.last.start_date).to eq(Date.new(2015, 4, 1))
-      expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(2016, 3).end_of_month)
+      expect(Dataset.last.datafiles.last.end_date).to eq(Date.new(2016).end_of_quarter)
     end
   end
 end
@@ -520,7 +430,7 @@ describe "passing the frequency page" do
     expect(page).to have_content("Add a link to your data")
   end
 
-  it "routes to the daily datafiles page and check for errors" do
+  it "routes to the daily datafiles page and checks for errors" do
     choose option: "daily"
     click_button "Save and continue"
     expect(page).to have_content("Add a link to your data")
@@ -541,54 +451,7 @@ describe "passing the frequency page" do
     expect(page).to_not have_content("Year")
   end
 
-  it "routes to the weekly datafiles page and check for errors" do
-    choose option: "weekly"
-    click_button "Save and continue"
-    expect(page).to have_content("Add a link to your data")
-    expect(page).to have_content("Start Date")
-    expect(page).to have_content("End Date")
-    fill_in "link[url]", with: "http://www.example.com/test.csv"
-    fill_in "link[name]", with: "Test datafile"
-    click_button "Save and continue"
-    expect(page).to have_content("Please enter a valid start day", count: 2)
-    expect(page).to have_content("Please enter a valid start month", count: 2)
-    expect(page).to have_content("Please enter a valid start year", count: 2)
-    expect(page).to have_content("Please enter a valid end day", count: 2)
-    expect(page).to have_content("Please enter a valid end month", count: 2)
-    expect(page).to have_content("Please enter a valid end year", count: 2)
-    fill_in "link[start_day]", with: "234"
-    fill_in "link[start_month]", with: "June"
-    fill_in "link[start_year]", with: "234"
-    fill_in "link[end_day]", with: "234"
-    fill_in "link[end_month]", with: "234"
-    fill_in "link[end_year]", with: "234"
-    click_button "Save and continue"
-    expect(page).to have_content("Please enter a valid start day", count: 2)
-    expect(page).to have_content("Please enter a valid start month", count: 2)
-    expect(page).to have_content("Please enter a valid start year", count: 2)
-    expect(page).to have_content("Please enter a valid end day", count: 2)
-    expect(page).to have_content("Please enter a valid end month", count: 2)
-    expect(page).to have_content("Please enter a valid end year", count: 2)
-    fill_in "link[start_day]", with: "31"
-    fill_in "link[start_month]", with: "02"
-    fill_in "link[start_year]", with: "2019"
-    fill_in "link[end_day]", with: "31"
-    fill_in "link[end_month]", with: "05"
-    fill_in "link[end_year]", with: "2019"
-    click_button "Save and continue"
-    expect(page).to_not have_content("Please enter a valid start day")
-    expect(page).to_not have_content("Please enter a valid start month", count: 2)
-    expect(page).to_not have_content("Please enter a valid start year", count: 2)
-    expect(page).to_not have_content("Please enter a valid end day", count: 2)
-    expect(page).to_not have_content("Please enter a valid end month", count: 2)
-    expect(page).to_not have_content("Please enter a valid end year", count: 2)
-    expect(page).to have_content("Please enter a valid start date", count: 2)
-    fill_in "link[start_month]", with: "01"
-    click_button "Save and continue"
-    expect(page).to have_content("Links to your data")
-  end
-
-  it "routes to the monthly datafiles page and check for errors" do
+  it "routes to the monthly datafiles page and checks for errors" do
     choose option: "monthly"
     click_button "Save and continue"
     expect(page).to have_content("Add a link to your data")
@@ -598,13 +461,13 @@ describe "passing the frequency page" do
     click_button "Save and continue"
     expect(page).to have_content("Please enter a valid month", count: 2)
     expect(page).to have_content("Please enter a valid year", count: 2)
-    fill_in "link[start_month]", with: "01"
-    fill_in "link[start_year]", with: "2019"
+    fill_in "link[month]", with: "01"
+    fill_in "link[year]", with: "2019"
     click_button "Save and continue"
     expect(page).to have_content("Links to your data")
   end
 
-  it "routes to the quarterly datafiles page and check for errors" do
+  it "routes to the quarterly datafiles page and checks for errors" do
     choose option: "quarterly"
     click_button "Save and continue"
     expect(page).to have_content("Add a link to your data")
@@ -615,12 +478,12 @@ describe "passing the frequency page" do
     expect(page).to have_content("Please select a quarter", count: 2)
     expect(page).to have_content("Please enter a valid year", count: 2)
     choose option: "2"
-    fill_in "link[start_year]", with: "2019"
+    fill_in "link[year]", with: "2019"
     click_button "Save and continue"
     expect(page).to have_content("Links to your data")
   end
 
-  it "routes to the yearly datafiles page and check for errors" do
+  it "routes to the yearly datafiles page and checks for errors" do
     choose option: "annually"
     click_button "Save and continue"
     expect(page).to have_content("Add a link to your data")
@@ -631,12 +494,12 @@ describe "passing the frequency page" do
     fill_in "link[name]", with: "Test datafile"
     click_button "Save and continue"
     expect(page).to have_content("Please enter a valid year", count: 2)
-    fill_in "link[start_year]", with: "2019"
+    fill_in "link[year]", with: "2019"
     click_button "Save and continue"
     expect(page).to have_content("Links to your data")
   end
 
-  it "routes to the yearly (financial) datafiles page and check for errors" do
+  it "routes to the yearly (financial) datafiles page and checks for errors" do
     choose option: "financial-year"
     click_button "Save and continue"
     expect(page).to have_content("Add a link to your data")
@@ -647,7 +510,7 @@ describe "passing the frequency page" do
     fill_in "link[name]", with: "Test datafile"
     click_button "Save and continue"
     expect(page).to have_content("Please enter a valid year", count: 2)
-    fill_in "link[start_year]", with: "2019"
+    fill_in "link[year]", with: "2019"
     click_button "Save and continue"
     expect(page).to have_content("Links to your data")
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,8 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
+ENV['LEGACY_HOST'] ||= "https://test.data.gov.uk"
+ENV['LEGACY_API_KEY'] ||= "123"
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
There is no clear user need (legacy only has 10 datasets marked as weekly). It makes full sync with legacy possible, resulting in an easier transition for publishers.

This PR removes the `weekly` option for datasets and introduces the requirement for dates when creating datafiles for daily datasets.

Trello: https://trello.com/c/DTTDnTUv/53-remove-weekly-frequency-from-datasets