### PR TITLE
Only push to legacy when publishing a dataset

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -45,8 +45,6 @@ class Dataset < ApplicationRecord
   scope :owned_by, ->(creator_id) { where(creator_id: creator_id) }
   scope :published, ->{ where(status: "published") }
 
-  after_update :update_legacy
-
   def is_readonly?
     if persisted? && self.harvested?
       errors[:base] << 'Harvested datasets cannot be modified.'
@@ -62,6 +60,7 @@ class Dataset < ApplicationRecord
       transaction do
         self.published!
         PublishingWorker.perform_async(self.id)
+        PublishToLegacyUpdateWorker.perform_async(self.id)
       end
     end
   end
@@ -176,10 +175,6 @@ class Dataset < ApplicationRecord
   end
 
   private
-
-  def update_legacy
-    PublishToLegacyUpdateWorker.perform_async(self.id)
-  end
 
   def set_initial_stage
     self.stage ||= 'initialised'


### PR DESCRIPTION
Otherwise, setting the frequency or the licence will trigger a push,
even before the dataset is published