### PR TITLE
Make sure that organisation data is indexed when syncing datasets

### DIFF
--- a/app/workers/legacy_publish_to_elastic_worker.rb
+++ b/app/workers/legacy_publish_to_elastic_worker.rb
@@ -1,8 +1,0 @@
-class LegacyPublishToElasticWorker
-  include Sidekiq::Worker
-
-  def perform(dataset)
-    logger.info "Attempting to publish dataset #{dataset.id}"
-    dataset.__elasticsearch__.index_document
-  end
-end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -86,7 +86,7 @@ namespace :import do
       counter += 1
       print "Completed #{counter}\r"
 
-      MetadataTools.add_dataset_metadata(obj, orgs_cache, theme_cache)
+      MetadataTools.persist(obj, orgs_cache, theme_cache)
     end
   end
 

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -6,7 +6,7 @@ namespace :sync do
   task legacy: :environment do |_, args|
     orgs_cache =  Organisation.all.pluck(:uuid, :id).to_h
     theme_cache = Theme.all.pluck(:title, :id).to_h
-    host = Rails.env.production? ? 'https://data.gov.uk' : 'https://test.data.gov.uk'
+    host = Rails.env.production? ? 'https://data.gov.uk/' : 'https://test.data.gov.uk/'
 
     legacy_dataset_sync = LegacyDatasetSync.new(
       orgs_cache: orgs_cache,

--- a/lib/util/legacy_dataset_sync.rb
+++ b/lib/util/legacy_dataset_sync.rb
@@ -31,17 +31,15 @@ class LegacyDatasetSync
   # Keep yielding recent packages until the metadata_modified and metadata_created
   # is earlier than yesterday.
   def get_legacy_datasets(server)
-    modified_datasets_url = "#{server}/api/3/action/package_search?q=metadata_modified:[NOW-1DAY%20TO%20NOW]"
-    new_datasets_url = "#{server}/api/3/action/package_search?q=metadata_created:[NOW-1DAY%20TO%20NOW]"
+    modified_datasets_url = URI::join(server, 'api/3/action/package_search?q=metadata_modified:[NOW-1DAY%20TO%20NOW]').to_s
+    new_datasets_url = URI::join(server, 'api/3/action/package_search?q=metadata_created:[NOW-1DAY%20TO%20NOW]').to_s
 
     new_legacy_datasets = fetch_json(new_datasets_url)
     modified_legacy_datasets = fetch_json(modified_datasets_url)
 
     [new_legacy_datasets, modified_legacy_datasets].each do |datasets|
-      if there_are? datasets
-        datasets['result']['results'].each do |pkg|
-          yield pkg
-        end
+      datasets.fetch('result', {}).fetch('results', []).each do |pkg|
+        yield pkg
       end
     end
   end
@@ -53,9 +51,5 @@ class LegacyDatasetSync
   rescue RestClient::ExceptionWithResponse
     @logger.error "Failed to make the request to #{url}"
     return nil
-  end
-
-  def there_are?(datasets)
-    datasets['result'] && datasets['result']['results']
   end
 end

--- a/lib/util/metadata_tools.rb
+++ b/lib/util/metadata_tools.rb
@@ -1,6 +1,16 @@
 module MetadataTools
 
-  def add_dataset_metadata(obj, orgs_cache, theme_cache)
+  def index(obj)
+    dataset = Dataset.find_by!(uuid: obj["id"])
+
+    dataset.__elasticsearch__.index_document({
+      index: ::Dataset.__elasticsearch__.index_name,
+      type: ::Dataset.__elasticsearch__.document_type,
+      id: dataset.id, body: dataset.as_indexed_json
+    })
+  end
+
+  def persist(obj, orgs_cache, theme_cache)
     d = Dataset.find_or_create_by(uuid: obj["id"])
     d.legacy_name = obj["name"]
     d.title = obj["title"]
@@ -226,7 +236,7 @@ module MetadataTools
     result["value"]
   end
 
-  module_function :add_dataset_metadata, :generate_summary, :convert_frequency, :add_inspire_metadata,
-    :dataset_type, :get_extra, :harvested?, :calculate_dates_for_month, :calculate_dates_for_year,
-    :documentation?, :get_start_end_date, :add_resource, :convert_location
+  module_function :persist, :index, :generate_summary, :convert_frequency, :add_inspire_metadata,
+                  :dataset_type, :get_extra, :harvested?, :calculate_dates_for_month, :calculate_dates_for_year,
+                  :documentation?, :get_start_end_date, :add_resource, :convert_location
 end

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -22,23 +22,6 @@ describe DatasetsController, type: :controller do
     expect(dataset.errors[:base]).to include("Harvested datasets cannot be modified.")
   end
 
-  it "updates legacy when a dataset is updated" do
-    user =  FactoryGirl.create(:user)
-    dataset = FactoryGirl.create(:dataset, links: [FactoryGirl.create(:link)])
-
-    sign_in(user)
-
-    patch :update, params: { uuid: dataset.uuid, name: dataset.name, dataset: { title: "New title" } }
-
-    dataset.reload
-
-    expect(dataset.title).to eq("New title")
-
-    expect(WebMock)
-      .to have_requested(:post, 'https://test.data.gov.uk/api/3/action/package_patch')
-      .once
-  end
-
   it "redirects to slugged URL" do
     user =  FactoryGirl.create(:user)
     organisation = FactoryGirl.create(:organisation, users: [user])

--- a/spec/lib/util/legacy_dataset_sync_spec.rb
+++ b/spec/lib/util/legacy_dataset_sync_spec.rb
@@ -2,53 +2,92 @@ require 'rails_helper'
 require 'util/legacy_dataset_sync'
 
 describe LegacyDatasetSync do
-  it 'Imports legacy datasets' do
-    orgs_cache =  Organisation.all.pluck(:uuid, :id).to_h
-    theme_cache = Theme.all.pluck(:title, :id).to_h
-
-    host = 'https://test.data.gov.uk'
+  before do
+    @orgs_cache =  Organisation.all.pluck(:uuid, :id).to_h
+    @theme_cache = Theme.all.pluck(:title, :id).to_h
+    @host = 'https://test.data.gov.uk'
     modified_datasets_query = '/api/3/action/package_search?q=metadata_modified:[NOW-1DAY%20TO%20NOW]'
     new_datasets_query = '/api/3/action/package_search?q=metadata_created:[NOW-1DAY%20TO%20NOW]'
-    modified_datasets_url = URI.join(host, modified_datasets_query)
-    new_datasets_url = URI.join(host, new_datasets_query)
-    package =  JSON.generate someDataset: { name: 'Awesome data' }
-    response = JSON.generate(result: { results: [package] })
+    @modified_datasets_url = URI.join(@host, modified_datasets_query)
+    @new_datasets_url = URI.join(@host, new_datasets_query)
+  end
 
-    first_dataset = double('first dataset')
-    second_dataset = double('second dataset')
+  describe 'There are modified and new legacy datasets to be imported' do
+    it 'Imports legacy datasets' do
+      package =  JSON.generate someDataset: { name: 'Awesome data' }
+      response = JSON.generate(result: { results: [package] })
 
-    legacy_dataset_sync = LegacyDatasetSync.new(
-      orgs_cache: orgs_cache,
-      theme_cache: theme_cache,
-      host: host,
-      logger: double('logger', info: '')
-    )
+      first_dataset = double('first dataset')
+      second_dataset = double('second dataset')
 
-    stub_request(:get, modified_datasets_url).to_return(status: 200, body: response)
-    stub_request(:get, new_datasets_url).to_return(status: 200, body: response)
+      legacy_dataset_sync = LegacyDatasetSync.new(
+        orgs_cache: @orgs_cache,
+        theme_cache: @theme_cache,
+        host: @host,
+        logger: double('logger', info: '')
+      )
 
-    allow(Dataset).to receive(:find_by).and_return([first_dataset, second_dataset])
-    allow(MetadataTools).to receive(:add_dataset_metadata)
-    allow(LegacyPublishToElasticWorker).to receive(:perform_async)
+      stub_request(:get, @modified_datasets_url).to_return(status: 200, body: response)
+      stub_request(:get, @new_datasets_url).to_return(status: 200, body: response)
 
-    legacy_dataset_sync.run
+      allow(Dataset).to receive(:find_by).and_return([first_dataset, second_dataset])
+      allow(MetadataTools).to receive(:persist)
+      allow(MetadataTools).to receive(:index)
 
-    expect(WebMock)
-      .to have_requested(:get, modified_datasets_url)
-      .once
+      legacy_dataset_sync.run
 
-    expect(WebMock)
-      .to have_requested(:get, new_datasets_url)
-      .once
+      expect(WebMock)
+        .to have_requested(:get, @modified_datasets_url)
+              .once
 
-    expect(MetadataTools)
-      .to have_received(:add_dataset_metadata)
-      .exactly(2).times
-      .with(package, orgs_cache, theme_cache)
+      expect(WebMock)
+        .to have_requested(:get, @new_datasets_url)
+              .once
 
-    expect(LegacyPublishToElasticWorker)
-      .to have_received(:perform_async)
-      .exactly(2).times
-      .with([first_dataset, second_dataset])
+      expect(MetadataTools)
+        .to have_received(:persist)
+              .exactly(2).times
+              .with(package, @orgs_cache, @theme_cache)
+
+      expect(MetadataTools)
+        .to have_received(:index)
+              .exactly(2).times
+              .with(package)
+    end
+
+    describe 'there are no modified or new datasets to be imported' do
+      it 'does not import legacy datasets' do
+        response = JSON.generate(result: { results: [] })
+
+        legacy_dataset_sync = LegacyDatasetSync.new(
+          orgs_cache: @orgs_cache,
+          theme_cache: @theme_cache,
+          host: @host,
+          logger: double('logger', info: '')
+        )
+
+        stub_request(:get, @modified_datasets_url).to_return(status: 200, body: response)
+        stub_request(:get, @new_datasets_url).to_return(status: 200, body: response)
+
+        allow(MetadataTools).to receive(:persist)
+        allow(MetadataTools).to receive(:index)
+
+        legacy_dataset_sync.run
+
+        expect(WebMock)
+          .to have_requested(:get, @modified_datasets_url)
+                .once
+
+        expect(WebMock)
+          .to have_requested(:get, @new_datasets_url)
+                .once
+
+        expect(MetadataTools)
+          .to_not have_received(:persist)
+
+        expect(MetadataTools)
+          .to_not have_received(:index)
+      end
+    end
   end
 end

--- a/spec/lib/util/legacy_dataset_sync_spec.rb
+++ b/spec/lib/util/legacy_dataset_sync_spec.rb
@@ -5,11 +5,11 @@ describe LegacyDatasetSync do
   before do
     @orgs_cache =  Organisation.all.pluck(:uuid, :id).to_h
     @theme_cache = Theme.all.pluck(:title, :id).to_h
-    @host = 'https://test.data.gov.uk'
-    modified_datasets_query = '/api/3/action/package_search?q=metadata_modified:[NOW-1DAY%20TO%20NOW]'
-    new_datasets_query = '/api/3/action/package_search?q=metadata_created:[NOW-1DAY%20TO%20NOW]'
-    @modified_datasets_url = URI.join(@host, modified_datasets_query)
-    @new_datasets_url = URI.join(@host, new_datasets_query)
+    @host = 'https://test.data.gov.uk/'
+    modified_datasets_query = 'api/3/action/package_search?q=metadata_modified:[NOW-1DAY%20TO%20NOW]'
+    new_datasets_query = 'api/3/action/package_search?q=metadata_created:[NOW-1DAY%20TO%20NOW]'
+    @modified_datasets_url = URI::join(@host, modified_datasets_query).to_s
+    @new_datasets_url = URI::join(@host, new_datasets_query).to_s
   end
 
   describe 'There are modified and new legacy datasets to be imported' do


### PR DESCRIPTION
- When syncing legacy make sure org data is indexed too!
- Refactor sync task
- Add test coverage for when there are no datasets to import
- Add more logging to aid debugging on staging and prod


