### PR TITLE
Remove seemingly obsolete 'stage' logic

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -5,7 +5,6 @@ class DatasetsController < ApplicationController
 
   def show
     authorize!(:read, @dataset)
-    @dataset.complete!
 
     if request_to_outdated_url?
       return redirect_to newest_dataset_path, status: :moved_permanently
@@ -41,8 +40,6 @@ class DatasetsController < ApplicationController
   end
 
   def publish
-    @dataset.complete!
-
     if @dataset.publishable?
       if @dataset.published?
         flash[:success] = I18n.t 'dataset_updated'

--- a/app/views/datasets/links/index.html.erb
+++ b/app/views/datasets/links/index.html.erb
@@ -52,7 +52,7 @@
   </p>
 
   <p>
-    <% if @dataset.initialised? %>
+    <% if @dataset.draft? %>
       <%= link_to 'Save and continue', new_dataset_doc_path(@dataset.uuid, @dataset.name), class: "button" %>
     <% else %>
       <%= link_to 'Save and continue', dataset_path(@dataset.uuid, @dataset.name), class: "button" %>

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -30,7 +30,6 @@ describe "dataset creation" do
       click_button "Save and continue"
 
       expect(Dataset.where(title: "my test dataset").size).to eq(1)
-      expect(Dataset.last.stage).to eq("initialised")
 
       # PAGE 2: Licence
       choose option: "uk-ogl"
@@ -76,7 +75,7 @@ describe "dataset creation" do
       expect(Dataset.last.docs.size).to eq(1)
       expect(Dataset.last.docs.last.url).to eq('https://localhost/doc')
       expect(Dataset.last.docs.last.name).to eq('my test doc')
-      expect(Dataset.last.stage).to eq("initialised")
+      expect(Dataset.last.status).to eq("draft")
 
       # Documents page
       expect(page).to have_content("Links to supporting documents")
@@ -85,7 +84,6 @@ describe "dataset creation" do
 
       # Page 9: Publish Page
       expect(Dataset.last.published?).to be(false)
-      expect(Dataset.last.stage).to eq("completed")
 
       expect(page).to have_content(Dataset.last.status)
       expect(page).to have_content(Dataset.last.organisation.title)


### PR DESCRIPTION
Dataset `stage` logic introduced with https://github.com/datagovuk/publish_data_beta/commit/f7b182f4 seems to be unused.

We set the dataset's stage to `completed` when the user reaches the last step of the dataset creation process, and when a dataset is published. But the only place we check the stage of a dataset is in a view where we check whether the value is `"initialised"`.