### PR TITLE
Remove stage column from datasets table

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -37,6 +37,10 @@ class Dataset < ApplicationRecord
   scope :owned_by, ->(creator_id) { where(creator_id: creator_id) }
   scope :published, ->{ where(status: "published") }
 
+  def self.columns
+    super.reject { |c| c.name == "stage" }
+  end
+
   def is_readonly?
     if persisted? && self.harvested?
       errors[:base] << 'Harvested datasets cannot be modified.'

--- a/db/migrate/20171108155801_remove_stage_from_datasets.rb
+++ b/db/migrate/20171108155801_remove_stage_from_datasets.rb
@@ -1,0 +1,5 @@
+class RemoveStageFromDatasets < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :datasets, :stage
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,9 @@
 
 ActiveRecord::Schema.define(version: 2017071231151258) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
     t.text "body"
@@ -107,7 +110,6 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "uuid"
-    t.string "stage"
     t.integer "theme_id"
     t.integer "secondary_theme_id"
     t.datetime "last_updated_at"


### PR DESCRIPTION
Removes obsolete column `stage` from the `datasets` table.

Follows https://github.com/datagovuk/publish_data_beta/pull/413.