### PR TITLE
Update structure of FIND dataset URLs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
     link_to title, { sort: column, direction: direction }, { class: css_class }
   end
 
-  def find_url(dataset_name)
-    "https://#{ENV['FIND_URL'] || ''}/dataset/#{dataset_name}"
+  def find_url(dataset_uuid, dataset_name)
+    "https://#{ENV['FIND_URL'] || ''}/dataset/#{dataset_uuid}/#{dataset_name}"
   end
 end

--- a/app/views/manage/_base.html.erb
+++ b/app/views/manage/_base.html.erb
@@ -25,7 +25,7 @@
         <tr>
           <th>
             <% if dataset.published? %>
-              <%= link_to dataset.title, find_url(dataset.name) %>
+              <%= link_to dataset.title, find_url(dataset.uuid, dataset.name) %>
             <% else %>
               <%= dataset.title %>
             <% end %>

--- a/app/views/manage/manage_own.html.erb
+++ b/app/views/manage/manage_own.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-box-highlight">
   <h1 class="bold-large"><%= flash[:success] %></h1>
   <h2>
-    <%= link_to "View it", find_url(flash[:extra]["name"]) %>
+    <%= link_to "View it", find_url(flash[:extra][:uuid], flash[:extra][:name]) %>
   </h2>
 </div>
 <% end %>

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -14,6 +14,10 @@ namespace :search do
             type: "string",
             index: "not_analyzed"
           },
+          uuid: {
+            type: "string",
+            index: "not_analyzed"
+          },
           location1: {
             type: 'string',
             fields: {


### PR DESCRIPTION
This PR updates Elastic Search's mapping to include `uuid`, so Find can get a dataset by its uuid.

Sister PR for Find: https://github.com/datagovuk/find_data_beta/pull/310.