### PR TITLE
Fix view it link

### DIFF
--- a/app/views/manage/manage_own.html.erb
+++ b/app/views/manage/manage_own.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-box-highlight">
   <h1 class="bold-large"><%= flash[:success] %></h1>
   <h2>
-    <%= link_to "View it", find_url(flash[:extra][:uuid], flash[:extra][:name]) %>
+    <%= link_to "View it", find_url(flash['extra']['uuid'], flash['extra']['name']) %>
   </h2>
 </div>
 <% end %>


### PR DESCRIPTION
The hash we are accessing to get the dataset uuid and name is not with indifferent access, so using symbolized keys returns `nil`. Which means the `find_url` method cannot put together the link to FIND. This PR changes to stringed keys.