### PR TITLE
Reduce memory for publish staging

### DIFF
--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -1,6 +1,6 @@
 applications:
 - name: publish-data-beta-staging
-  memory: 512M
+  memory: 256M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
   env:
     RAILS_ENV: staging


### PR DESCRIPTION
We're currently hitting our memory limit on PaaS because we're launching more apps now. I've reduced the amount of memory the staging app server uses by half.