### PR TITLE
Use process health check on workers

### DIFF
--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -12,3 +12,4 @@ applications:
   - publish-beta-production-pg
   - publish-production-secrets
   - logit-ssl-drain
+  health-check-type: process

--- a/staging-worker-manifest.yml
+++ b/staging-worker-manifest.yml
@@ -13,3 +13,4 @@ applications:
   - beta-staging-redis
   - logit-ssl-drain
   - beta-staging-elasticsearch
+  health-check-type: process


### PR DESCRIPTION
Blue green deploys wipe out some of the settings, and this is one i'd forgotten about. Since sidekiq doesn't expose itself on `:80`, it's better to just check that the process is active instead. This was the behaviour before but it is not being repro'd in new deploys.