### PR TITLE
Fixes for search.rake

### DIFF
--- a/app/services/alias_updater_service.rb
+++ b/app/services/alias_updater_service.rb
@@ -27,10 +27,9 @@ class AliasUpdaterService
         }
       ]
     }
-  rescue => e
-    msg = "Could not remove alias.\n #{e.message}"
-    logger.error msg
-    Raven.capture_error msg
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    msg = 'Alias not currently assigned to an index'
+    logger.info msg
   end
 
   def assign_alias_to_new_index
@@ -47,6 +46,6 @@ class AliasUpdaterService
   rescue => e
     msg = "Could not update alias.\n #{e.message}"
     logger.error msg
-    Raven.capture_error msg
+    Raven.capture_exception msg
   end
 end

--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -41,7 +41,7 @@ class DatasetsIndexerService
   rescue => e
     msg = "There was an error indexing datasets:\n#{e.message}"
     logger.error msg
-    Raven.capture msg
+    Raven.capture_exception msg
   end
 
   def index_mapping

--- a/app/services/index_deletion_service.rb
+++ b/app/services/index_deletion_service.rb
@@ -22,7 +22,7 @@ class IndexDeletionService
   def select_indexes_for_deletion(indexes)
     # Ensure that the three most recent indexes are not deleted
     indexes
-      .select { |index_name| index_name.include? index_alias }
+      .select { |index_name| index_name.include? "#{index_alias}_" }
       .sort_by { |index_name| Time.parse(index_name.gsub(/"#{index_alias}_"/, '')) }
       .drop(3)
   end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,7 +1,7 @@
 namespace :search do
   desc "Reindex all datasets"
   task :reindex, [:batch_size] => :environment do |_, args|
-    batch_size = args.batch_size.to_i || 50
+    batch_size = args.batch_size.nil? ? 50 : args.batch_size.to_i
     logger = Logger.new(STDOUT)
     client = Dataset.__elasticsearch__.client
     date = Time.now.strftime('%Y%m%d%H%M%S')

--- a/spec/services/index_deletion_service_spec.rb
+++ b/spec/services/index_deletion_service_spec.rb
@@ -9,6 +9,7 @@ describe IndexDeletionService do
     index_from_yesterday = 'datasets-test_20171121070000'
     index_from_last_week = 'datasets-test_20171112070000'
     index_from_last_month = 'datasets-test_20171022070000'
+    legacy_index = 'datasets-development'
 
     indexes = [
       index_from_this_morning,
@@ -32,15 +33,13 @@ describe IndexDeletionService do
 
     index_deleter.run
 
-    indexes_to_keep.each do |index|
-      expect(client_double)
-        .to receive(:'indices.delete')
-        .with(index)
-        .never
-    end
+    expect(client_double)
+      .to receive(:'indices.delete')
+      .with(indexes_to_keep)
+      .never
 
     expect(client_double)
       .to_not receive(:'indices.delete')
-      .with(index_from_this_morning)
+      .with([index_from_this_morning, legacy_index])
   end
 end


### PR DESCRIPTION
- Includes fast-fail if an index exists with the same name as the alias. This index needs to be deleted manually before continuing. 
- Fixes for error handling and default batch size. 
- Improved error messaging.