### PR TITLE
Reinstate LEGACY_HOST env var

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -21,7 +21,7 @@ namespace :import do
     organisation_count = 0
     child_organisation_count = 0
     relationships = {}
-    host = ENV['LEGACY_HOST'] || 'https://data.gov.uk/'
+    host = ENV['LEGACY_HOST']
     path = 'data/dumps/data.gov.uk-ckan-meta-data-latest.organizations.jsonl.zip'
     url = URI::join(host, path).to_s
     file = download_data('latest_legacy_organisations', url, logger)
@@ -89,7 +89,7 @@ namespace :import do
     orgs_cache = Organisation.all.pluck(:uuid, :id).to_h
     theme_cache = Theme.all.pluck(:title, :id).to_h
     counter = 0
-    host = ENV['LEGACY_HOST'] || 'https://data.gov.uk/'
+    host = ENV['LEGACY_HOST']
     path = 'data/dumps/data.gov.uk-ckan-meta-data-latest.v2.jsonl.zip'
     url = URI::join(host, path).to_s
     file = download_data('latest_legacy_datasets', url, logger)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -21,7 +21,7 @@ namespace :import do
     organisation_count = 0
     child_organisation_count = 0
     relationships = {}
-    host = 'https://data.gov.uk/'
+    host = ENV['LEGACY_HOST'] || 'https://data.gov.uk/'
     path = 'data/dumps/data.gov.uk-ckan-meta-data-latest.organizations.jsonl.zip'
     url = URI::join(host, path).to_s
     file = download_data('latest_legacy_organisations', url, logger)
@@ -89,7 +89,7 @@ namespace :import do
     orgs_cache = Organisation.all.pluck(:uuid, :id).to_h
     theme_cache = Theme.all.pluck(:title, :id).to_h
     counter = 0
-    host = 'https://data.gov.uk/'
+    host = ENV['LEGACY_HOST'] || 'https://data.gov.uk/'
     path = 'data/dumps/data.gov.uk-ckan-meta-data-latest.v2.jsonl.zip'
     url = URI::join(host, path).to_s
     file = download_data('latest_legacy_datasets', url, logger)
@@ -131,7 +131,7 @@ def read_json_from_zip(filename, logger)
 end
 
 def download_data(file_name, url, logger)
-  logger.info('Downloading data')
+  logger.info("Downloading data from #{url}")
   file = Tempfile.new(file_name)
   file.binmode
   file.write(RestClient.get(url).body)


### PR DESCRIPTION
In staging environment datasets should be imported from 'test.data.gov.uk' - this is the value of LEGACY_HOST in staging (in production LEGACY_HOST is 'data.gov.uk')