### PR TITLE
Remove column removal patch

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -37,10 +37,6 @@ class Dataset < ApplicationRecord
   scope :owned_by, ->(creator_id) { where(creator_id: creator_id) }
   scope :published, ->{ where(status: "published") }
 
-  def self.columns
-    super.reject { |c| c.name == "stage" }
-  end
-
   def is_readonly?
     if persisted? && self.harvested?
       errors[:base] << 'Harvested datasets cannot be modified.'


### PR DESCRIPTION
Now that the column has been removed, we can remove the patch.

More info: https://blog.codeship.com/rails-migrations-zero-downtime/