### PR TITLE
Revert "Automate db migration on cloud foundry (#445)"

### DIFF
--- a/lib/tasks/cloud_foundry.rake
+++ b/lib/tasks/cloud_foundry.rake
@@ -1,7 +1,0 @@
-namespace :cf do
-  desc "Only run on the first application instance"
-  task :on_first_instance do
-    instance_index = JSON.parse(ENV["VCAP_APPLICATION"])["instance_index"] rescue nil
-    exit(0) unless instance_index == 0
-  end
-end

--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -2,7 +2,6 @@ applications:
 - name: publish-data-beta
   memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
-  command: bundle exec rake cf:on_first_instance db:migrate
   env:
     RAILS_ENV: production
     RACK_ENV: production

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -2,7 +2,6 @@ applications:
 - name: publish-data-beta-staging
   memory: 256M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
-  command: bundle exec rake cf:on_first_instance db:migrate
   env:
     RAILS_ENV: staging
     RACK_ENV: staging


### PR DESCRIPTION
This reverts commit c6b3d904dd731c80960d89ab6866cff56b3e291a, which was causing deploys to fail.